### PR TITLE
Fixed OW_init() fail when parsing command line options before calling it

### DIFF
--- a/module/owlib/src/c/ow_opt.c
+++ b/module/owlib/src/c/ow_opt.c
@@ -578,6 +578,7 @@ GOOD_OR_BAD owopt_packed(const char *params)
 
 	// analyze argv/argc as if real command line arguments
 	ArgCopy( argc, argv ) ;
+	optind = 1;
 
 	while (ret == 0) {
 		if ((option_char = getopt_long(argc, argv, OWLIB_OPT, owopts_long, NULL)) == -1) {


### PR DESCRIPTION
Hello,

I encountered a problem if I parsed command line options with `getopt*` functions before calling `OW_init`. Init failed and returned -1. It have been fixed by setting `optind` to 1.