### PR TITLE
Add pkg-config entry for owcapi

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -51,6 +51,9 @@ AC_CONFIG_MACRO_DIR([src/scripts/m4])
 AC_CANONICAL_TARGET
 AM_INIT_AUTOMAKE(${PACKAGE}, ${VERSION})dnl
 
+PKG_PROG_PKG_CONFIG
+PKG_INSTALLDIR
+
 # Process config.h.in
 AH_TOP([
 #ifndef OWCONFIG_H
@@ -1757,6 +1760,7 @@ AC_CONFIG_FILES([
 	module/owcapi/src/c/Makefile
 	module/owcapi/src/example/Makefile
 	module/owcapi/src/example++/Makefile
+	module/owcapi/owcapi.pc
 
 	module/owtap/Makefile
 

--- a/module/owcapi/.gitignore
+++ b/module/owcapi/.gitignore
@@ -1,0 +1,1 @@
+owcapi.pc

--- a/module/owcapi/Makefile.am
+++ b/module/owcapi/Makefile.am
@@ -1,2 +1,3 @@
 SUBDIRS = src
 
+pkgconfig_DATA = owcapi.pc

--- a/module/owcapi/owcapi.pc.in
+++ b/module/owcapi/owcapi.pc.in
@@ -1,0 +1,10 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: owcapi
+Description: OWFS C API
+Version: @VERSION@
+Cflags: -I${includedir}
+Libs: -L${libdir} -lowcapi

--- a/src/scripts/m4/pkg-compat.m4
+++ b/src/scripts/m4/pkg-compat.m4
@@ -1,0 +1,23 @@
+# pkg-compat.m4 - Backport of pkg.m4 macros for old hosts.   -*- Autoconf -*-
+
+
+dnl PKG_INSTALLDIR([DIRECTORY])
+dnl -------------------------
+dnl Since: 0.27
+dnl
+dnl Substitutes the variable pkgconfigdir as the location where a module
+dnl should install pkg-config .pc files. By default the directory is
+dnl $libdir/pkgconfig, but the default can be changed by passing
+dnl DIRECTORY. The user can override through the --with-pkgconfigdir
+dnl parameter.
+AC_DEFUN([PKG_INSTALLDIR],
+[m4_pushdef([pkg_default], [m4_default([$1], ['${libdir}/pkgconfig'])])
+m4_pushdef([pkg_description],
+    [pkg-config installation directory @<:@]pkg_default[@:>@])
+AC_ARG_WITH([pkgconfigdir],
+    [AS_HELP_STRING([--with-pkgconfigdir], pkg_description)],,
+    [with_pkgconfigdir=]pkg_default)
+AC_SUBST([pkgconfigdir], [$with_pkgconfigdir])
+m4_popdef([pkg_default])
+m4_popdef([pkg_description])
+])dnl PKG_INSTALLDIR


### PR DESCRIPTION
This allows downstream packages to use PKG_CHECK_MODULES to pull in owcapi compilation and linking flags, rather than hardcoding them.

According to the pkg-config version parsing rules, the version "3.2p2" will not be parsed as "3 2 2", but as "3 2 p 2" (the p is considered the third component of the version). Fortunately, when comparing numeric and alphabetic components, pkg-config will consider the numeric version newer. So, if in the future, the 'p' is replaced with '.', version ordering will remain consistent.

A backport of PKG_INSTALLDIR is provided, since it's a relatively new addition. By relatively new, I mean it was added 6 years ago, but there's still plenty of build hosts running older versions.