### PR TITLE
add uninstall target to module/owmon and module/owtap Makefile

### DIFF
--- a/module/owmon/Makefile.am
+++ b/module/owmon/Makefile.am
@@ -4,3 +4,5 @@ install:
 	@INSTALL@ -d $(DESTDIR)$(bindir)
 	@INSTALL@ -m 755 owmon.tcl $(DESTDIR)$(bindir)/owmon
 
+uninstall:
+	@RM@ -f $(DESTDIR)$(bindir)/owmon

--- a/module/owtap/Makefile.am
+++ b/module/owtap/Makefile.am
@@ -4,3 +4,5 @@ install:
 	@INSTALL@ -d $(DESTDIR)$(bindir)
 	@INSTALL@ -m 755 owtap.tcl $(DESTDIR)$(bindir)/owtap
 
+uninstall:
+	@RM@ -f $(DESTDIR)$(bindir)/owtap


### PR DESCRIPTION
`make install && make uninstall` should remove all installed files
but `$(DESTDIR)$(bindir)/owmon` and `$(DESTDIR)$(bindir)/owtap`
were left over due to a lacking uninstall target.