### PR TITLE
`getpagesize` is not portable, use instead `sysconf(_SC_PAGESIZE)`

### DIFF
--- a/module/owlib/src/c/ow_ds1wm.c
+++ b/module/owlib/src/c/ow_ds1wm.c
@@ -135,7 +135,7 @@ GOOD_OR_BAD DS1WM_detect(struct port_in *pin)
 	}
 	LEVEL_DEBUG("DS1WM at address %p",(void *)base);
 	
-	in->master.ds1wm.mm_size = (size_t) getpagesize() ;
+	in->master.ds1wm.mm_size = (size_t) sysconf(_SC_PAGESIZE) ;
 	in->master.ds1wm.base = base ;
 	in->master.ds1wm.page_offset = base % in->master.ds1wm.mm_size ;
 	in->master.ds1wm.page_start = base - in->master.ds1wm.page_offset ;


### PR DESCRIPTION
On Darwin I'm unable to compile with `-Werror` because `getpagesize` has been dropped in POSIX.1-2001 and is no more available.

Really I do not know if the code in `module/owlib/src/c/ow_ds1wm.c` is still relevant to OWFS (is the DS1WM chip still available?, moreover this code is really linux-only, because it relies on `/dev/mem`), but nevertheless I think that due to the monolithic structure of `owlib` it is better to keep the sources updated.

Reference: <http://man7.org/linux/man-pages/man2/getpagesize.2.html>