### PR TITLE
Fix generation of OW.pm

### DIFF
--- a/module/swig/perl5/Makefile.am
+++ b/module/swig/perl5/Makefile.am
@@ -37,7 +37,7 @@ OW/blib/lib/OW.pm: OW/ow_wrap.c
 	$(MAKE) -C OW -fMakefile
 	@INSTALL@ -d OW/blib/lib
 	@INSTALL@ OW/OW.pm OW/blib/lib/
-	@ECHO@ >> OW/blib/lib/OW.pm 'our $$VERSION='\''@VERSION@'\'' ;'
+	printf '%s\n' 'our $$VERSION='\''@VERSION@'\'' ; 1;' >> OW/blib/lib/OW.pm
 
 install-data-local: OW/Makefile OW/ow_wrap.c OW/blib/lib/OW.pm
 	$(MAKE) -C OW install DESTDIR="$(DESTDIR)"


### PR DESCRIPTION
- Avoid using ``@ECHO@``, which doesn't quote the '%s\n' argument properly
  on this system, embedding a literal 'n' in the generated OW.pm.
  This issue can be seen also in the debian package of libow-perl, which is currently broken.
  Fixed by using printf directly.
- Append a true return value (1) at the end of the module instead of
  returning a version string.