### PR TITLE
owcapi: Add OW_visible to check for path visibility

### DIFF
--- a/module/owcapi/src/c/owcapi.c
+++ b/module/owcapi/src/c/owcapi.c
@@ -132,6 +132,32 @@ int OW_present(const char *path)
 	return ReturnAndErrno(ret);
 }
 
+int OW_visible(const char *path)
+{
+	int ret = -ENOENT;
+	struct parsedname s_pn;
+
+	if (API_access_start() == 0) {
+		if (FS_ParsedName(path, &s_pn) == 0) {
+			switch(FS_visible(&s_pn)) {
+				case visible_always:
+				case visible_now:
+					ret = 0;
+					break;
+				case visible_never:
+				case visible_not_now:
+					ret = -ENOENT;
+					break;
+			}
+			FS_ParsedName_destroy(&s_pn);
+		} else {
+			ret = -ENOENT;
+		}
+		API_access_end();
+	}
+	return ReturnAndErrno(ret);
+}
+
 ssize_t OW_lread(const char *path, char *buffer, const size_t size, const off_t offset)
 {
 	ssize_t ret = -EACCES;		/* current buffer string length */

--- a/module/owcapi/src/include/owcapi.h
+++ b/module/owcapi/src/include/owcapi.h
@@ -89,6 +89,17 @@ extern "C" {
 	 */
 	int OW_present(const char *path);
 
+	/* OW_visible -- check if path is visible
+	   path is OWFS style name,
+	   "" or "/" for root directory
+	   "01.23456708ABDE" for device directory
+	   "10.468ACE13579B/temperature for a specific device property
+
+	   return value = 0 ok
+                    < 0 error
+	 */
+	int OW_visible(const char *path);
+
 /* OW_put -- data write
   path is OWFS style name,
     "05.468ACE13579B/PIO.A for a specific device property


### PR DESCRIPTION
OW_present did not take into account path visibility. I was considering extending OW_present to check visibility, but, in owlib, presence and visibility are treated as different concepts, so owcapi should reflect
that.