### PR TITLE
typos in manpages and strings

### DIFF
--- a/module/owftpd/ChangeLog
+++ b/module/owftpd/ChangeLog
@@ -107,7 +107,7 @@
   systems with both RFC 2553 and XNET formats
 
 2001-03-27, Shane Kerr <shane@time-travellers.org>
-- Fixed bug where wrong server address was used on initalization of
+- Fixed bug where wrong server address was used on initialization of
   ftp_server class.  Passive probably didn't work in the 0.3.x series
   for IPv4!
 

--- a/module/owftpd/src/c/file_cd.c
+++ b/module/owftpd/src/c/file_cd.c
@@ -181,7 +181,7 @@ static void WildLexCD(struct cd_parse_s *cps, ASCII * match)
 {
 	struct parsedname pn;
 
-	LEVEL_DEBUG("FTP Wildcard patern matching: Path=%s, Pattern=%s, rest=%s", SAFESTRING(cps->buffer), SAFESTRING(match), SAFESTRING(cps->rest));
+	LEVEL_DEBUG("FTP Wildcard pattern matching: Path=%s, Pattern=%s, rest=%s", SAFESTRING(cps->buffer), SAFESTRING(match), SAFESTRING(cps->rest));
 	/* Check potential length */
 	if (strlen(cps->buffer) + OW_FULLNAME_MAX + 2 > PATH_MAX) {
 		cps->ret = -ENAMETOOLONG;

--- a/module/owftpd/src/c/file_list.c
+++ b/module/owftpd/src/c/file_list.c
@@ -254,7 +254,7 @@ static void WildLexParse(struct file_parse_s *fps, ASCII * match)
 	struct parsedname pn;
 	/* Embedded callback function */
 
-	LEVEL_DEBUG("FTP Wildcard patern matching: Path=%s, Pattern=%s, File=%s", SAFESTRING(fps->buffer), SAFESTRING(match), SAFESTRING(fps->rest));
+	LEVEL_DEBUG("FTP Wildcard pattern matching: Path=%s, Pattern=%s, File=%s", SAFESTRING(fps->buffer), SAFESTRING(match), SAFESTRING(fps->rest));
 
 	/* Check potential length */
 	if (strlen(fps->buffer) + OW_FULLNAME_MAX + 2 > PATH_MAX) {

--- a/module/owlib/src/c/ow_bae.c
+++ b/module/owlib/src/c/ow_bae.c
@@ -95,7 +95,7 @@ WRITE_FUNCTION(FS_w_32) ;
 #define _FC_EEPROM_PAGE_SIZE   512
 #define _FC_SDCARD_SECTOR_SIZE 512
 #define _FC_MAX_EEPROM_PAGES    32
-#define _FC_EEPROM_OFFSET   0x0000 //changed adressing scheme, valid from 0911 models 
+#define _FC_EEPROM_OFFSET   0x0000 //changed addressing scheme, valid from 0911 models
 #define _FC_MAX_FLASH_SIZE  0x4000
 #define _FC_MAX_INTERLEAVE     255
 #define _FC02_MEMORY_SIZE      128

--- a/module/owlib/src/c/ow_ds9097U.c
+++ b/module/owlib/src/c/ow_ds9097U.c
@@ -453,7 +453,7 @@ static GOOD_OR_BAD DS2480_detect_serial(struct connection_in *in)
 {
 	in->pown->state = cs_virgin ;
 	if ( BAD(DS2480_initialize_repeatedly(in)) ) {
-		LEVEL_DEBUG("Could not initilize the DS9097U even after several tries") ;
+		LEVEL_DEBUG("Could not initialize the DS9097U even after several tries") ;
 		COM_close(in) ;
 		return gbBAD ;
 	}

--- a/module/owlib/src/c/ow_ds9490.c
+++ b/module/owlib/src/c/ow_ds9490.c
@@ -628,7 +628,7 @@ static RESET_TYPE DS9490_reset(const struct parsedname *pn)
 			if (val & COMMCMDERRORRESULT_NRS) {
 				// empty bus detected, no presence pulse detected
 				in->AnyDevices = anydevices_no;
-				LEVEL_DATA("no presense pulse detected");
+				LEVEL_DATA("no presence pulse detected");
 			}
 		}
 	}

--- a/module/owlib/src/c/ow_parse_external.c
+++ b/module/owlib/src/c/ow_parse_external.c
@@ -384,7 +384,7 @@ void AddProperty( char * input_string, enum external_type et )
 		goto cleanup;
 	}
 
-	// persistance
+	// persistence
 	owfree(s_dummy);
 	GetQuotedString( dummy ) ;
 	switch ( s_dummy[0] ) {
@@ -404,7 +404,7 @@ void AddProperty( char * input_string, enum external_type et )
 			s_change = fc_uncached ;
 			break ;
 		default:
-			LEVEL_DEFAULT("Unrecognized persistance <%s> for property <%s> family <%s>",s_dummy,s_property,s_family);
+			LEVEL_DEFAULT("Unrecognized persistence <%s> for property <%s> family <%s>",s_dummy,s_property,s_family);
 			goto cleanup;
 	}
 

--- a/module/owlib/src/c/ow_server_enet.c
+++ b/module/owlib/src/c/ow_server_enet.c
@@ -225,7 +225,7 @@ static GOOD_OR_BAD OWServer_Enet_reopen_prompt(struct connection_in *in)
 	char cmd_response[1+in->CRLF_size] ;
 	
 	if ( BAD( OWServer_Enet_read( BYTE_string(cmd_response), 1, in )) ) {
-		LEVEL_DEBUG("Error reading inital telnet prompt" ) ;
+		LEVEL_DEBUG("Error reading initial telnet prompt" ) ;
 		return gbBAD ;
 	}
 	switch( cmd_response[0] ) {

--- a/module/owshell/src/c/ow_help.c
+++ b/module/owshell/src/c/ow_help.c
@@ -38,7 +38,7 @@ void ow_help(void)
 		   "  -R --Rankine                   |Rankine temperature scale\n"
 		   "  -f --format                    |format for 1-wire unique serial IDs display\n"
 		   "                                 |  f[.]i[[.]c] f-amily i-d c-rc (all in hex)\n"
-           "     --hex                       |data in hexidecimal format\n"
+           "     --hex                       |data in hexadecimal format\n"
            "     --size                      |size of data in bytes\n"
            "     --offset                    |start of read/write in field\n"
            "     --dir                       |add a trailing '/' for directories\n"

--- a/module/owshell/src/c/ow_opt.c
+++ b/module/owshell/src/c/ow_opt.c
@@ -40,8 +40,8 @@ const struct option owopts_long[] = {
 
 	{"hex", no_argument, &hexflag, 1 },
 	{"HEX", no_argument, &hexflag, 1 },
-	{"hexidecimal", no_argument, &hexflag, 1 },
-	{"HEXIDECIMAL", no_argument, &hexflag, 1 },
+	{"hexadecimal", no_argument, &hexflag, 1 },
+	{"HEXADECIMAL", no_argument, &hexflag, 1 },
 
 	{"dir", no_argument, &slashflag, 1 },
 	{"slash", no_argument, &slashflag, 1 },

--- a/module/owshell/src/c/owusbprobe.c
+++ b/module/owshell/src/c/owusbprobe.c
@@ -264,7 +264,7 @@ static void describe_usb_device(const dev_info *dev, const char *ttys_found) {
 			 pid == 0x6014 || pid == 0x6015)) {
 		char addr[255];
 		snprintf(addr, sizeof(addr), "ftdi:s:0x%04x:0x%04x:%s", vid, pid, dev->serial);
-		log("This device is identified as a generic FTDI adapter. To address it, use the following adressing:\n");
+		log("This device is identified as a generic FTDI adapter. To address it, use the following addressing:\n");
 		log("  %s\n", addr);
 
 		if(pid == 0x6001) {
@@ -297,7 +297,7 @@ static void describe_usb_device(const dev_info *dev, const char *ttys_found) {
 		log("  --usb %d:%d", dev->busNo, dev->devAddr);
 		log("  --usb %d\n", dev->usbNr);
 
-		log("Please be aware that these adressing schemes are non-stable, and numbers may\n"
+		log("Please be aware that these addressing schemes are non-stable, and numbers may\n"
 			"change between reboots or reconnects. Please read owserver manual page for more info.");
 	}else if((vid == 0x067B && pid == 0x2303) || (vid == 0x0B6A && pid == 0x5A03)) {
 		// DS2480b-emulating devices

--- a/src/man/man1/description.1so
+++ b/src/man/man1/description.1so
@@ -38,5 +38,5 @@ properties of the device are represented as simple files that can be read and wr
 Details of the individual slave or master design are hidden behind a consistent interface. The goal is to 
 provide an easy set of tools for a software designer to create monitoring or control applications. There 
 are some performance enhancements in the implementation, including data caching, parallel access to bus 
-masters, and aggregation of device communication. Still the fundemental goal has been ease of use, flexibility 
+masters, and aggregation of device communication. Still the fundamental goal has been ease of use, flexibility
 and correctness rather than speed.

--- a/src/man/man1/device.1so
+++ b/src/man/man1/device.1so
@@ -191,12 +191,12 @@ Used for testing and development. No actual hardware is needed. Useful for separ
 is a list of comma-separated 1-wire devices in the following formats. Note that a valid CRC8 code is created automatically.
 .TP
 10,05,21
-Hexidecimal
+Hexadecimal
 .I family codes
 (the DS18S20, DS2405 and DS1921 in this example).
 .TP
 10.12AB23431211
-A more complete hexidecimal unique address. Useful when an actual hardware device should be simulated.
+A more complete hexadecimal unique address. Useful when an actual hardware device should be simulated.
 .TP
 DS2408,DS2489
 The 1-wire device name. (Full ID cannot be speciifed in this format).

--- a/src/man/man1/owmon.man
+++ b/src/man/man1/owmon.man
@@ -73,7 +73,7 @@ with
 .B owmon (1)
 is a pure
 .I Tcl/TK
-program and will run whereever
+program and will run wherever
 .I Tcl/TK
 is available (Windows, Macintosh, Linux, Unix)
 .SH LINKS

--- a/src/man/man1/owshell.man
+++ b/src/man/man1/owshell.man
@@ -164,7 +164,7 @@ there is not persistent connection with the 1-wire bus, no caching and no multit
 and performs a quick set of queries.
 .PP
 .B owserver (1)
-performs the actual 1-wire connection (to physical 1-wire busses or other
+performs the actual 1-wire connection (to physical 1-wire buses or other
 .B owserver
 programs), performs concurrency locking, caching, and error collection.
 .PP
@@ -225,9 +225,9 @@ process can be local or remote.
 If the server option is not specified, the default is the local machine and the IANA allocated default port of 4304. Thus "\-s localhost:4304" is the equivalent.
 .SH DATA OPTIONS
 .SH \-\-hex
-Hexidecimal mode. For reading data, each byte of character will be displayed as two characrters 0-9ABCDEF. Most useful for reading memory locations. No spaces between data.
+Hexadecimal mode. For reading data, each byte of character will be displayed as two characrters 0-9ABCDEF. Most useful for reading memory locations. No spaces between data.
 .P
-Writing data in hexidecimal mode just means that the data should be given as one long hexidecimal string.
+Writing data in hexadecimal mode just means that the data should be given as one long hexadecimal string.
 .SH \-\-start=offset
 Read or write memory locations starting at the offset byte rather than the beginning. An offset of 0 means the beginning (and is the default).
 .P

--- a/src/man/man1/owtap.man
+++ b/src/man/man1/owtap.man
@@ -92,7 +92,7 @@ on the original port (4304) and offering a new port (3000) for clients.
 .B owtap (1)
 is a pure
 .I Tcl/TK
-program and will run whereever
+program and will run wherever
 .I Tcl/TK
 is available (Windows, Macintosh, Linux, Unix)
 .SH LINKS

--- a/src/man/man3/DS1921.man
+++ b/src/man/man3/DS1921.man
@@ -232,7 +232,7 @@ properties.
 .SS undertemp/count.0 ... undertemp/count.11 undertemp/count.ALL
 .I read-only, unsigned integer
 .br
-Number of sampling periods that the Thermochron stayed out of range durring a mission. Each sampling period is
+Number of sampling periods that the Thermochron stayed out of range during a mission. Each sampling period is
 .I mission/frequency
 minutes long.
 .SS overtemp/end.0 ... overtemp/end.11 overtemp/end.ALL

--- a/src/man/man3/DS1991.man
+++ b/src/man/man3/DS1991.man
@@ -66,7 +66,7 @@ Non-volatile memory with password protection.
 .br
 Initialize one of the three secure data areas and set a new password.
 .PP
-The extension (hex_pwd) is the new 8-byte password in hexidecimal (e.g. password.000204006080A0C0E for bytes 0,2,4,6,8,10,12,14)
+The extension (hex_pwd) is the new 8-byte password in hexadecimal (e.g. password.000204006080A0C0E for bytes 0,2,4,6,8,10,12,14)
 .PP
 The data must be "1" or "yes" to actually reset the subkey.
 .PP
@@ -81,7 +81,7 @@ of one of the secure subkey areas
 .PP
 The extension (hex_pwd) is the existing 8-byte 
 .I password 
-in hexidecimal (e.g. password.00020406080A0C0E for bytes 0,2,4,6,8,10,12,14)
+in hexadecimal (e.g. password.00020406080A0C0E for bytes 0,2,4,6,8,10,12,14)
 .PP
 The data portion is 8 bytes that will be used as a new 
 .I password.
@@ -90,7 +90,7 @@ The data portion is 8 bytes that will be used as a new
 .br
 Read or write data in one of the three sucure data areas.
 .PP
-The extension (hex_pwd) is the existing 8-byte password in hexidecimal (e.g. password.00020406080A0C0E for bytes 0,2,4,6,8,10,12,14)
+The extension (hex_pwd) is the existing 8-byte password in hexadecimal (e.g. password.00020406080A0C0E for bytes 0,2,4,6,8,10,12,14)
 .PP
 The data portion binary data. Up to 48 bytes in each subkey area, starting at location 0. If the wrong password is specified, "random data" is returned on read and data is silently ignored on write.
 .SS subkey[0|1|2]/id.hex_pwd
@@ -99,7 +99,7 @@ The data portion binary data. Up to 48 bytes in each subkey area, starting at lo
 Read or write the subkey
 .I id.
 .PP
-The extension (hex_pwd) is the existing 8-byte password in hexidecimal (e.g. password.00020406080A0C0E for bytes 0,2,4,6,8,10,12,14)
+The extension (hex_pwd) is the existing 8-byte password in hexadecimal (e.g. password.00020406080A0C0E for bytes 0,2,4,6,8,10,12,14)
 .PP
 The data portion 8 binary bytes. This is the subkey 
 .I id.
@@ -119,7 +119,7 @@ is an iButton with password protected non-volatile memory. Data is read/written 
 .PP
 In theory, choosing an incorrect password is hard to discern because the chip responds normally but with incorrect data. There is a published analysis suggesting that the "random data" follows a pattern and so a concerted attack might be successful.
 .PP
-The password (in hexidecimal) is used a the file extension
+The password (in hexadecimal) is used a the file extension
 .B 02.1234123414/subkey0/id.
 .I password
 allowing a password to be passed to the program within the filesystem paradigm.

--- a/src/man/man3/DS2404.man
+++ b/src/man/man3/DS2404.man
@@ -353,7 +353,7 @@ Both the
 .B DS2404 (3)
 and
 .B DS2404S (3)
-have 1-wire and 3-wire interfaces, which might be useful for transferring data between the 2 buses. They act as a passive slave to both busses. The
+have 1-wire and 3-wire interfaces, which might be useful for transferring data between the 2 buses. They act as a passive slave to both buses. The
 .B DS2404 (3)
 and
 .B DS2404S (3)

--- a/src/man/man3/DS2408.man
+++ b/src/man/man3/DS2408.man
@@ -118,7 +118,7 @@ configured as STRB output
 .br
 Specifies whether the device has performed power-on reset. This bit can only
 be cleared to 0 under software control. As long as this bit is 1 the device
-will allways respond to a conditional search.
+will always respond to a conditional search.
 .SS out_of_testmode
 .I write-only, yes-no
 .br

--- a/src/man/man3/DS2409.man
+++ b/src/man/man3/DS2409.man
@@ -106,7 +106,7 @@ branch switched in
 .SS discharge
 .I write-only, yes-no
 .br
-Writing a non-zero value to this property will electrically reset both the main and auxillary branches of the 1-wire bus by dropping power for 100 milliseconds. All devices on those branches will lose parasitic power and reset to power-up defaults. As a side effect, both
+Writing a non-zero value to this property will electrically reset both the main and auxiliary branches of the 1-wire bus by dropping power for 100 milliseconds. All devices on those branches will lose parasitic power and reset to power-up defaults. As a side effect, both
 .I event
 flags and thus, the alarm state, are cleared, too.
 .SS event.0 event.1 event.ALL event.BYTE

--- a/src/man/man3/DS2760.man
+++ b/src/man/man3/DS2760.man
@@ -442,7 +442,7 @@ is a class of battery charging controllers. There are minor hardware difference 
 .B DS2760, DS2761
 and
 .B DS2762
-battery chip, but they are indistiguishable to the software.
+battery chip, but they are indistinguishable to the software.
 .PP
 A number of interesting devices can be built with the
 .B DS276x 

--- a/src/man/man3/DS28E04.man
+++ b/src/man/man3/DS28E04.man
@@ -112,7 +112,7 @@ PIO powers up 1
 .br
 Specifies whether the device has performed power-on reset. This bit can only
 be cleared to 0 under software control. As long as this bit is 1 the device
-will allways respond to a conditional search.
+will always respond to a conditional search.
 .SS set_alarm
 .I read-write, integer unsigned (0-333)
 .br

--- a/src/man/man3/EDS.man
+++ b/src/man/man3/EDS.man
@@ -609,7 +609,7 @@ Device name. E.g: "EDS0071"
 .SS device_id
 .I read-only, unsigned
 .br
-Number corresponding to the hexidecimal type. E.g:
+Number corresponding to the hexadecimal type. E.g:
 .br
 EDS0071 -> 0x0071 -> 113 in decimal
 .SH STANDARD PROPERTIES

--- a/src/man/man3/LCD.man
+++ b/src/man/man3/LCD.man
@@ -74,7 +74,7 @@ is an aggregate of the properties, comma separated. Read atomically.
 .br
 Cumulative sum of the
 .I counters
-property. To reset, write a zero. The cumulative counter can have any value written, which allows preservation of counts accross program restarts if the value at program termination is stored.
+property. To reset, write a zero. The cumulative counter can have any value written, which allows preservation of counts across program restarts if the value at program termination is stored.
 .br
 Reading
 .I cumulative

--- a/src/man/man3/addressing.3so
+++ b/src/man/man3/addressing.3so
@@ -19,7 +19,7 @@ All 1-wire devices are factory assigned a unique 64-bit address. This address is
 8 bits
 .IP
 .PP
-Addressing under OWFS is in hexidecimal, of form:
+Addressing under OWFS is in hexadecimal, of form:
 .IP
 .B 01.123456789ABC
 .PP

--- a/src/man/man3/description.3so
+++ b/src/man/man3/description.3so
@@ -38,5 +38,5 @@ properties of the device are represented as simple files that can be read and wr
 Details of the individual slave or master design are hidden behind a consistent interface. The goal is to 
 provide an easy set of tools for a software designer to create monitoring or control applications. There 
 are some performance enhancements in the implementation, including data caching, parallel access to bus 
-masters, and aggregation of device communication. Still the fundemental goal has been ease of use, flexibility 
+masters, and aggregation of device communication. Still the fundamental goal has been ease of use, flexibility
 and correctness rather than speed.

--- a/src/man/man3/standard.3so
+++ b/src/man/man3/standard.3so
@@ -25,18 +25,18 @@ in reverse order, which is often used in other applications and labeling.
 .SS crc8
 .I read-only, ascii
 .br
-The 8-bit error correction portion. Uses cyclic redundancy check. Computed from the preceding 56 bits of the unique ID number. Given as upper case hexidecimal digits (0-9A-F).
+The 8-bit error correction portion. Uses cyclic redundancy check. Computed from the preceding 56 bits of the unique ID number. Given as upper case hexadecimal digits (0-9A-F).
 .SS family
 .I read-only, ascii
 .br
 The 8-bit family code. Unique to each
 .I type
-of device. Given as upper case hexidecimal digits (0-9A-F).
+of device. Given as upper case hexadecimal digits (0-9A-F).
 .SS id
 .SS r_id
 .I read-only, ascii
 .br
-The 48-bit middle portion of the unique ID number. Does not include the family code or CRC. Given as upper case hexidecimal digits (0-9A-F).
+The 48-bit middle portion of the unique ID number. Does not include the family code or CRC. Given as upper case hexadecimal digits (0-9A-F).
 .br
 .I r id
 is the
@@ -49,7 +49,7 @@ in reverse order, which is often used in other applications and labeling.
 Uses an extension of the 1-wire design from iButtonLink company that associated 1-wire physical connections with a unique 1-wire code. If the connection is behind a
 .B Link Locator
 the
-.I locator will show a unique 8-byte number (16 character hexidecimal) starting with family code FE.
+.I locator will show a unique 8-byte number (16 character hexadecimal) starting with family code FE.
 .br
 If no
 .B Link Locator

--- a/src/man/man5/description.5so
+++ b/src/man/man5/description.5so
@@ -38,5 +38,5 @@ properties of the device are represented as simple files that can be read and wr
 Details of the individual slave or master design are hidden behind a consistent interface. The goal is to 
 provide an easy set of tools for a software designer to create monitoring or control applications. There 
 are some performance enhancements in the implementation, including data caching, parallel access to bus 
-masters, and aggregation of device communication. Still the fundemental goal has been ease of use, flexibility 
+masters, and aggregation of device communication. Still the fundamental goal has been ease of use, flexibility
 and correctness rather than speed.

--- a/src/man/man5/owfs.man
+++ b/src/man/man5/owfs.man
@@ -278,7 +278,7 @@ specific
 .I nozero
 #   turn off zeroconf announcement
 .br
-. I annouce
+. I announce
 = name  # name of announced service (optional)
 .br
 .I autoserver

--- a/src/man/mann/description.nso
+++ b/src/man/mann/description.nso
@@ -38,5 +38,5 @@ properties of the device are represented as simple files that can be read and wr
 Details of the individual slave or master design are hidden behind a consistent interface. The goal is to 
 provide an easy set of tools for a software designer to create monitoring or control applications. There 
 are some performance enhancements in the implementation, including data caching, parallel access to bus 
-masters, and aggregation of device communication. Still the fundemental goal has been ease of use, flexibility 
+masters, and aggregation of device communication. Still the fundamental goal has been ease of use, flexibility
 and correctness rather than speed.


### PR DESCRIPTION
All of them have been found by the lintian program while building the Debian package