### PR TITLE
Use AC_HEADER_MAJOR to find the major macro

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -189,9 +189,10 @@ m4_include([src/scripts/m4/acx_pthread.m4])
 # Checks for header files.
 AC_HEADER_DIRENT
 AC_HEADER_STDC
-AC_CHECK_HEADERS([asm/types.h arpa/inet.h sys/ioctl.h sys/mkdev.h sys/socket.h sys/sysmacros.h sys/time.h sys/times.h sys/types.h sys/param.h sys/uio.h feature_tests.h fcntl.h netinet/in.h stdlib.h string.h strings.h sys/file.h syslog.h termios.h unistd.h limits.h stdint.h features.h getopt.h resolv.h semaphore.h])
+AC_CHECK_HEADERS([asm/types.h arpa/inet.h sys/ioctl.h sys/socket.h sys/time.h sys/times.h sys/types.h sys/param.h sys/uio.h feature_tests.h fcntl.h netinet/in.h stdlib.h string.h strings.h sys/file.h syslog.h termios.h unistd.h limits.h stdint.h features.h getopt.h resolv.h semaphore.h])
 AC_CHECK_HEADERS([linux/limits.h linux/types.h netdb.h dlfcn.h])
 AC_CHECK_HEADERS(sys/event.h sys/inotify.h)
+AC_HEADER_MAJOR
 
 # Test if debugging out enabled
 ENABLE_DEBUG="true"

--- a/module/owlib/src/include/ow.h
+++ b/module/owlib/src/include/ow.h
@@ -188,13 +188,12 @@
 #include <netdb.h>				/* for getaddrinfo */
 #endif							/* HAVE_NETDB_H */
 
-#ifdef HAVE_SYS_SYSMACROS_H
-#include <sys/sysmacros.h>			/* for major() */
-#endif							/* HAVE_SYS_SYSMACROS_H */
-
-#ifdef HAVE_SYS_MKDEV_H
-#include <sys/mkdev.h>			/* for major() on Solaris */
-#endif							/* HAVE_SYS_MKDEV_H */
+/* for major() if sys/types.h is not enough */
+#ifdef MAJOR_IN_MKDEV
+#include <sys/mkdev.h>
+#elif defined MAJOR_IN_SYSMACROS
+#include <sys/sysmacros.h>
+#endif
 
 #include <stddef.h> // for offsetof()
 

--- a/module/ownet/c/src/include/ow.h
+++ b/module/ownet/c/src/include/ow.h
@@ -118,9 +118,12 @@
 
 #include <netdb.h>				/* addrinfo */
 
-#ifdef HAVE_SYS_MKDEV_H
-#include <sys/mkdev.h>			/* for major() */
-#endif							/* HAVE_SYS_MKDEV_H */
+/* for major() if sys/types.h is not enough */
+#ifdef MAJOR_IN_MKDEV
+#include <sys/mkdev.h>
+#elif defined MAJOR_IN_SYSMACROS
+#include <sys/sysmacros.h>
+#endif
 
 /* Can't include search.h when compiling owperl on Fedora Core 1. */
 #ifndef SKIP_SEARCH_H


### PR DESCRIPTION
According to https://sourceware.org/ml/libc-alpha/2015-11/msg00255.html
AC_HEADER_MAJOR is the portable macro to use in order to find the major/minor macros

This patch also fix the header in ownet that was not fixed
in the previous patch (0d5e4ba51d2b90a64f5d310d715ed367bbcc8996)
[perhaps the include can be totally removed here?]