### PR TITLE
Add \r to Http header to satisfy RFC2616 specification

### DIFF
--- a/module/owhttpd/src/c/owhttpd_present.c
+++ b/module/owhttpd/src/c/owhttpd_present.c
@@ -24,7 +24,7 @@ void HTTPstart(struct OutputControl * oc, const char *status, const enum content
 	size_t l = strftime(d, sizeof(d), "%a, %d %b %Y %T GMT", gmtime(&t));
 
 	fprintf(out, "HTTP/1.0 %s\r\n", status);
-	fprintf(out, "Date: %*s\n", (int) l, d);
+	fprintf(out, "Date: %*s\r\n", (int) l, d);
 	fprintf(out, "Server: %s\r\n", SVERSION);
 	fprintf(out, "Last-Modified: %*s\r\n", (int) l, d);
 	/*


### PR DESCRIPTION
RFC2616 specification for HTTP/1.1 defines the sequence CR LF as the end-of-line marker for all protocol elements except the entity-body.

Without this fix it is difficult to read the JSON formatted results into a .NET application using `HttpClient` as it throws an exception for the malformed header.

Fixes #19 