### PR TITLE
Update some python syntax to support both python2 and python3

### DIFF
--- a/module/ownet/python/examples/check_ow.py
+++ b/module/ownet/python/examples/check_ow.py
@@ -41,10 +41,10 @@ path   = args[2]
 
 try:
     s = ownet.Sensor(path, server=server, port=port)
-except ownet.exUnknownSensor, ex:
+except ownet.exUnknownSensor as ex:
     print 'OW ' + nagios.unknown[1] + ' - unknown sensor ' + str(ex)
     sys.exit(nagios.unknown[0])
-except socket.error, ex:
+except socket.error as ex:
     print 'OW ' + nagios.unknown[1] + ' - communication error ' + str(ex)
     sys.exit(nagios.unknown[0])
 

--- a/module/ownet/python/ownet/__init__.py
+++ b/module/ownet/python/ownet/__init__.py
@@ -248,7 +248,7 @@ class Sensor(object):
             #print 'Sensor.__getattr__(%s)' % name
             attr = self._connection.read(object.__getattribute__(self, '_attrs')[name])
         except:
-            raise AttributeError, name
+            raise AttributeError(name)
 
         return attr
 
@@ -379,7 +379,7 @@ class Sensor(object):
                         # print 'branch_entry(%s)' % str(branch_entry)
                         try:
                             self._connection.read(branch_entry + '/type')
-                        except exUnknownSensor, ex:
+                        except exUnknownSensor as ex:
                             continue
                         yield Sensor(branch_entry, connection=self._connection)
 

--- a/module/ownet/python/ownet/connection.py
+++ b/module/ownet/python/ownet/connection.py
@@ -224,7 +224,7 @@ class Connection(object):
 
         #print 'Connection.unpack("%s")' % msg
         if len(msg) is not 24:
-            raise exInvalidMessage, msg
+            raise exInvalidMessage(msg)
 
         val          = struct.unpack('iiiiii', msg)
         version      = socket.ntohl(val[0])

--- a/module/ownet/ruby/sensor.rb
+++ b/module/ownet/ruby/sensor.rb
@@ -51,17 +51,17 @@ module OWNet
         if @attrs.include? name
           @connection.read(@attrs[name])
         else
-          raise AttributeError, name
+          raise AttributeError(name)
         end
       elsif name[-1] == "="[0] and args.size == 1
         name = name.to_s[0..-2]
         if @attrs.include? name
           @connection.write(@attrs[name], args[0])
         else
-          raise AttributeError, name
+          raise AttributeError(name)
         end
       else
-        raise NoMethodError, "undefined method \"#{name}\" for #{self}:#{self.class}"
+        raise NoMethodError("undefined method \"#{name}\" for #{self}:#{self.class}")
       end
     end
     

--- a/module/swig/python/examples/check_ow.py
+++ b/module/swig/python/examples/check_ow.py
@@ -59,7 +59,7 @@ if options.temperature:
 try:
     ow.error_print(ow.error_print.suppressed) # needed to exclude debug output which confuses nagios
     ow.init(init)
-except ow.exUnknownSensor, ex:
+except ow.exUnknownSensor as ex:
     exit(nagios.unknown[0], 'unable to initialize sensor adapter ' + str(ex))
 
 
@@ -72,7 +72,7 @@ else:
 
 try:
     s = ow.Sensor(sensor)
-except ow.exUnknownSensor, ex:
+except ow.exUnknownSensor as ex:
     exit(nagios.unknown, 'unknown sensor ' + str(ex))
 
 

--- a/module/swig/python/ow/__init__.py
+++ b/module/swig/python/ow/__init__.py
@@ -343,7 +343,7 @@ class Sensor( object ):
         try:
             return owfs_get(object.__getattribute__(self, '_attrs')[name])
         except KeyError:
-            raise AttributeError, name
+            raise AttributeError(name)
 
 
     def __setattr__( self, name, value ):
@@ -424,7 +424,7 @@ class Sensor( object ):
             for entry in list.split( ',' ):
                 try:
                     owfs_get(entry + 'type')
-                except exUnknownSensor, ex:
+                except exUnknownSensor as ex:
                     yield entry.split( '/' )[ 0 ]
 
 
@@ -464,14 +464,14 @@ class Sensor( object ):
                 path = self._usePath + '/' + branch
                 try:
                     list = owfs_get( path )
-                except exUnknownSensor, ex:
+                except exUnknownSensor as ex:
                     continue
                 if list:
                     for branch_entry in list.split( ',' ):
                         branch_path = self._usePath + '/' + branch + '/' + branch_entry.split( '/' )[ 0 ]
                         try:
                             owfs_get( branch_path + '/type' )
-                        except exUnknownSensor, ex:
+                        except exUnknownSensor as ex:
                             continue
                         yield Sensor( branch_path )
 
@@ -481,7 +481,7 @@ class Sensor( object ):
                 for branch_entry in list.split( ',' ):
                     try:
                         owfs_get( branch_entry + 'type' )
-                    except exUnknownSensor, ex:
+                    except exUnknownSensor as ex:
                         continue
                     path = self._usePath + '/' + branch_entry.split( '/' )[ 0 ]
                     if path[ :2 ] == '//':

--- a/module/swig/python/unittest/ds1420.py
+++ b/module/swig/python/unittest/ds1420.py
@@ -35,7 +35,7 @@ import ow
 __version__ = '0.0'
 
 if not os.path.exists( 'owtest.ini' ):
-    raise IOError, 'owtest.ini'
+    raise IOError('owtest.ini')
 
 config = ConfigParser.ConfigParser( )
 config.read( 'owtest.ini' )

--- a/module/swig/python/unittest/ds2408.py
+++ b/module/swig/python/unittest/ds2408.py
@@ -43,7 +43,7 @@ __version__ = '0.0'
 
 
 if not os.path.exists( 'owtest.ini' ):
-    raise IOError, 'owtest.ini'
+    raise IOError('owtest.ini')
 
 config = ConfigParser.ConfigParser( )
 config.read( 'owtest.ini' )

--- a/module/swig/python/unittest/ds2409.py
+++ b/module/swig/python/unittest/ds2409.py
@@ -36,7 +36,7 @@ import ow
 __version__ = '0.0'
 
 if not os.path.exists( 'owtest.ini' ):
-    raise IOError, 'owtest.ini'
+    raise IOError('owtest.ini')
 
 config = ConfigParser.ConfigParser( )
 config.read( 'owtest.ini' )

--- a/module/swig/python/unittest/owload.py
+++ b/module/swig/python/unittest/owload.py
@@ -37,7 +37,7 @@ load    = True
 class OWLoad( unittest.TestCase ):
     def setUp( self ):
         if not os.path.exists( 'owtest.ini' ):
-            raise IOError, 'owtest.ini'
+            raise IOError('owtest.ini')
 
         self.config = ConfigParser.ConfigParser( )
         self.config.read( 'owtest.ini' )

--- a/module/swig/python/unittest/owsensors.py
+++ b/module/swig/python/unittest/owsensors.py
@@ -38,7 +38,7 @@ class OWSensors( unittest.TestCase ):
     def setUp( self ):
         #print 'OWSensors.setup'
         if not os.path.exists( 'owtest.ini' ):
-            raise IOError, 'owtest.ini'
+            raise IOError('owtest.ini')
 
         self.config = ConfigParser.ConfigParser( )
         self.config.read( 'owtest.ini' )


### PR DESCRIPTION
change exception syntax (for raise and except)

The previous patch was not enough. It allowed owfs compilation, but not the use of python modules with python3.