### PR TITLE
Ie cache tweaks

### DIFF
--- a/module/owlib/src/c/ow_ie_switch_master.c
+++ b/module/owlib/src/c/ow_ie_switch_master.c
@@ -780,36 +780,34 @@ static ZERO_OR_ERROR switch_master_write_relay_state(struct one_wire_query *owq)
 			val = 255;
 		}
 
-		if (val != master->relays[port][channel].state) {
-			LEVEL_DEBUG("Setting relay port %d channel %d to %d", port, channel, val);
+		LEVEL_DEBUG("Setting relay port %d channel %d to %d", port, channel, val);
 
-			BYTE write_string[] = { _1W_SWITCH_MASTER_SET_RELAY_STATE, 0, 0, 0, 0};
-			BYTE command_ok[1];
+		BYTE write_string[] = { _1W_SWITCH_MASTER_SET_RELAY_STATE, 0, 0, 0, 0};
+		BYTE command_ok[1];
 
-			write_string[1] = port;
-			write_string[2] = channel;
-			write_string[3] = val;
+		write_string[1] = port;
+		write_string[2] = channel;
+		write_string[3] = val;
 
-			BYTE crc = CRC8compute(PN(owq)->sn, 8, 0);
-			crc = CRC8compute(write_string, 4, crc);
-			write_string[4] = crc;
+		BYTE crc = CRC8compute(PN(owq)->sn, 8, 0);
+		crc = CRC8compute(write_string, 4, crc);
+		write_string[4] = crc;
 
-			struct transaction_log t[] = {
-					TRXN_START,
-					TRXN_WRITE5(write_string),
-					TRXN_READ1(command_ok),
-					TRXN_END,
-			};
+		struct transaction_log t[] = {
+				TRXN_START,
+				TRXN_WRITE5(write_string),
+				TRXN_READ1(command_ok),
+				TRXN_END,
+		};
 
-			RETURN_ERROR_IF_BAD(BUS_transaction(t, PN(owq)));
+		RETURN_ERROR_IF_BAD(BUS_transaction(t, PN(owq)));
 
-			if (command_ok[0]) {
-				LEVEL_DEBUG("Device reported bad command");
-				return 1;
-			}
-
-			master->relays[port][channel].state = val;
+		if (command_ok[0]) {
+			LEVEL_DEBUG("Device reported bad command");
+			return 1;
 		}
+
+		master->relays[port][channel].state = val;
 
 		while (!isdigit(*next) && (next != NULL)) {
 			next++;
@@ -880,36 +878,34 @@ static ZERO_OR_ERROR switch_master_write_relay_mode(struct one_wire_query *owq)
 			val = 255;
 		}
 
-		if (val != master->relays[port][channel].state) {
-			LEVEL_DEBUG("Setting relay mode for port %d channel %d to %d", port, channel, val);
+		LEVEL_DEBUG("Setting relay mode for port %d channel %d to %d", port, channel, val);
 
-			BYTE write_string[] = { _1W_SWITCH_MASTER_SET_RELAY_MODE, 0, 0, 0, 0};
-			BYTE command_ok[1];
+		BYTE write_string[] = { _1W_SWITCH_MASTER_SET_RELAY_MODE, 0, 0, 0, 0};
+		BYTE command_ok[1];
 
-			write_string[1] = port;
-			write_string[2] = channel;
-			write_string[3] = val;
+		write_string[1] = port;
+		write_string[2] = channel;
+		write_string[3] = val;
 
-			BYTE crc = CRC8compute(PN(owq)->sn, 8, 0);
-			crc = CRC8compute(write_string, 4, crc);
-			write_string[4] = crc;
+		BYTE crc = CRC8compute(PN(owq)->sn, 8, 0);
+		crc = CRC8compute(write_string, 4, crc);
+		write_string[4] = crc;
 
-			struct transaction_log t[] = {
-					TRXN_START,
-					TRXN_WRITE5(write_string),
-					TRXN_READ1(command_ok),
-					TRXN_END,
-			};
+		struct transaction_log t[] = {
+				TRXN_START,
+				TRXN_WRITE5(write_string),
+				TRXN_READ1(command_ok),
+				TRXN_END,
+		};
 
-			RETURN_ERROR_IF_BAD(BUS_transaction(t, PN(owq)));
+		RETURN_ERROR_IF_BAD(BUS_transaction(t, PN(owq)));
 
-			if (command_ok[0]) {
-				LEVEL_DEBUG("Device reported bad command");
-				return 1;
-			}
-
-			master->relays[port][channel].state = val;
+		if (command_ok[0]) {
+			LEVEL_DEBUG("Device reported bad command");
+			return 1;
 		}
+
+		master->relays[port][channel].state = val;
 
 		while (!isdigit(*next) && (next != NULL)) {
 			next++;
@@ -979,36 +975,34 @@ static ZERO_OR_ERROR switch_master_write_relay_timeout(struct one_wire_query *ow
 			val = 255;
 		}
 
-		if (val != master->relays[port][channel].timeout) {
-			LEVEL_DEBUG("Setting relay timeout for port %d channel %d to %d", port, channel, val);
+		LEVEL_DEBUG("Setting relay timeout for port %d channel %d to %d", port, channel, val);
 
-			BYTE write_string[] = { _1W_SWITCH_MASTER_SET_RELAY_TIMEOUT, 0, 0, 0, 0};
-			BYTE command_ok[1];
+		BYTE write_string[] = { _1W_SWITCH_MASTER_SET_RELAY_TIMEOUT, 0, 0, 0, 0};
+		BYTE command_ok[1];
 
-			write_string[1] = port;
-			write_string[2] = channel;
-			write_string[3] = val;
+		write_string[1] = port;
+		write_string[2] = channel;
+		write_string[3] = val;
 
-			BYTE crc = CRC8compute(PN(owq)->sn, 8, 0);
-			crc = CRC8compute(write_string, 4, crc);
-			write_string[4] = crc;
+		BYTE crc = CRC8compute(PN(owq)->sn, 8, 0);
+		crc = CRC8compute(write_string, 4, crc);
+		write_string[4] = crc;
 
-			struct transaction_log t[] = {
-					TRXN_START,
-					TRXN_WRITE5(write_string),
-					TRXN_READ1(command_ok),
-					TRXN_END,
-			};
+		struct transaction_log t[] = {
+				TRXN_START,
+				TRXN_WRITE5(write_string),
+				TRXN_READ1(command_ok),
+				TRXN_END,
+		};
 
-			RETURN_ERROR_IF_BAD(BUS_transaction(t, PN(owq)));
+		RETURN_ERROR_IF_BAD(BUS_transaction(t, PN(owq)));
 
-			if (command_ok[0]) {
-				LEVEL_DEBUG("Device reported bad command");
-				return 1;
-			}
-
-			master->relays[port][channel].timeout = val;
+		if (command_ok[0]) {
+			LEVEL_DEBUG("Device reported bad command");
+			return 1;
 		}
+
+		master->relays[port][channel].timeout = val;
 
 		while (!isdigit(*next) && (next != NULL)) {
 			next++;

--- a/module/owlib/src/c/ow_infernoembedded.c
+++ b/module/owlib/src/c/ow_infernoembedded.c
@@ -67,6 +67,7 @@ READ_FUNCTION(ie_get_device);
 READ_FUNCTION(ie_get_version);
 READ_FUNCTION(ie_get_status);
 WRITE_FUNCTION(ie_boot_firmware_updater);
+WRITE_FUNCTION(ie_refresh_cache);
 
 /* Inferno Embedded RGBW Controller */
 VISIBLE_FUNCTION(is_visible_rgbw_device);
@@ -116,6 +117,7 @@ static struct filetype InfernoEmbedded[] = {
 	{"version", PROPERTY_LENGTH_UNSIGNED, NON_AGGREGATE, ft_unsigned, fc_volatile, ie_get_version, NO_WRITE_FUNCTION, VISIBLE, NO_FILETYPE_DATA, },
 	{"status", PROPERTY_LENGTH_UNSIGNED, NON_AGGREGATE, ft_unsigned, fc_volatile, ie_get_status, NO_WRITE_FUNCTION, VISIBLE, NO_FILETYPE_DATA, },
 	{"enter_firmware_update", PROPERTY_LENGTH_YESNO, NON_AGGREGATE, ft_yesno, fc_static, NO_READ_FUNCTION, ie_boot_firmware_updater, VISIBLE, NO_FILETYPE_DATA, },
+	{"refresh", PROPERTY_LENGTH_YESNO, NON_AGGREGATE, ft_yesno, fc_static, NO_READ_FUNCTION, ie_refresh_cache, VISIBLE, NO_FILETYPE_DATA, },
 
 	/* Inferno Embedded RGBW Controller */
 	{"rgbw_all_off", PROPERTY_LENGTH_YESNO, NON_AGGREGATE, ft_yesno, fc_static, NO_READ_FUNCTION, rgbw_all_off, is_visible_rgbw_device, NO_FILETYPE_DATA, },
@@ -584,6 +586,24 @@ static ZERO_OR_ERROR ie_boot_firmware_updater(struct one_wire_query *owq)
 	}
 	return 0;
 }
+
+/**
+ * Refresh device info
+ * @param owq the query
+ */
+static ZERO_OR_ERROR ie_refresh_cache(struct one_wire_query *owq)
+{
+#if OW_UTHASH
+	ie_device *device;
+	if (BAD(device_info(PN(owq), &device))) {
+		return gbBAD;
+	}
+	invalidate_device(&device);
+#endif
+
+	return gbGOOD;
+}
+
 
 #include "ow_ie_rgbw_controller.c"
 #include "ow_ie_firmware_updater.c"


### PR DESCRIPTION
Tweak handling of Inferno Embedded cached metadata to allow for the possibility that the cached data is out of sync with the device (eg. if the device has been power cycled while in the bootloader).