### PR TITLE
Fix crash when parsing Inferno Embedded switch master inputs

### DIFF
--- a/module/owlib/src/c/ow_ie_switch_master.c
+++ b/module/owlib/src/c/ow_ie_switch_master.c
@@ -811,7 +811,7 @@ static ZERO_OR_ERROR switch_master_write_relay_state(struct one_wire_query *owq)
 			master->relays[port][channel].state = val;
 		}
 
-		while (!isdigit(*next) && (next != NULL)) {
+		while (!isdigit(*next) && (*next != '\0')) {
 			next++;
 		}
 	}
@@ -911,7 +911,7 @@ static ZERO_OR_ERROR switch_master_write_relay_mode(struct one_wire_query *owq)
 			master->relays[port][channel].state = val;
 		}
 
-		while (!isdigit(*next) && (next != NULL)) {
+		while (!isdigit(*next) && (*next != '\0')) {
 			next++;
 		}
 	}
@@ -1010,7 +1010,7 @@ static ZERO_OR_ERROR switch_master_write_relay_timeout(struct one_wire_query *ow
 			master->relays[port][channel].timeout = val;
 		}
 
-		while (!isdigit(*next) && (next != NULL)) {
+		while (!isdigit(*next) && (*next != '\0')) {
 			next++;
 		}
 	}


### PR DESCRIPTION
This patch fixes a buffer overrun when parsing incoming strings for Inferno Embedded SwitchMaster devices.