### PR TITLE
update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,16 @@
 language: c
 
 os:
-  - linux
-  - osx
+- linux
+- osx
 
 compiler:
-  - clang
-  - gcc
+- clang
+- gcc
 
 
 addons:
+
   apt:
     packages:
 # only have check 0.9 on trusty.
@@ -19,14 +20,15 @@ addons:
     - libavahi-client-dev
     - swig
 
-before_install:
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install swig; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install openldap libiconv php; fi
+  homebrew:
+    packages:
+    - swig
+    - php
 
 before_script:
-  - ./bootstrap
+- ./bootstrap
 
 script:
-  - ./configure && make -j 2
+- ./configure && make -j 2
 # libcheck no present
 #  - make check


### PR DESCRIPTION
this should solve recent compilation problems for OSX in travis.

Needs some work for allowing xenial image in linux: in fact I was not able to have swig3.0 and php7.0 work together: see <https://github.com/miccoli/owfs/tree/feature/travis-xenial> and <https://travis-ci.org/miccoli/owfs/builds/479631656>