### PR TITLE
updating travis CI configuration, fix #47

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,34 +1,55 @@
-language: c
+#
+# Travis CI configuration
+#
+# - Linux: the Travis PHP installation does not work with swig3
+#   we install the standard bionic package php7.2 and direct
+#   config to use with the configure options listed in $CONFOPTS
+# - osx: we use the homebrew php. Note that on osx 'compiler: gcc' is
+#   an alias for 'compiler: clang'. Therefore we build only with clang.
+#
 
-os:
-- linux
-- osx
+language: c
+dist: bionic
 
 compiler:
 - clang
 - gcc
+
+os:
+- linux
+
+env: CONFOPTS="--with-phpconfig=/usr/bin/php-config7.2 --with-php=/usr/bin/php7.2"
+
+jobs:
+  include:
+    - os: osx
+      env:
 
 
 addons:
 
   apt:
     packages:
-# only have check 0.9 on trusty.
-#    - check
-# Only have libusb-dev 0.1.. we want 0.9.1+
-#    - libusb-dev
+    - check
     - libavahi-client-dev
-    - swig
+    - libftdi-dev
+    - libfuse-dev
+    - libusb-1.0-0-dev
+    - php7.2-dev
+    - swig3.0
+    - uthash-dev
 
   homebrew:
     packages:
-    - swig
+    - check
     - php
+    - swig
+    update: true
 
 before_script:
 - ./bootstrap
 
 script:
-- ./configure && make -j 2
-# libcheck no present
-#  - make check
+- ./configure ${CONFOPTS}
+- make
+- make check


### PR DESCRIPTION
Update Travis CI configuration for using ubuntu/bionic image, closes #47 

Fix php configuration in Linux; test OSX with clang C compiler only.