### PR TITLE
Fix compilation with GCC10

### DIFF
--- a/module/owserver/src/c/owserver.c
+++ b/module/owserver/src/c/owserver.c
@@ -36,6 +36,8 @@
 
 #include "owserver.h"
 
+pthread_mutex_t persistence_mutex ;
+
 /* --- Prototypes ------------ */
 static void SetupAntiloop(int argc, char **argv);
 

--- a/module/owserver/src/include/owserver.h
+++ b/module/owserver/src/include/owserver.h
@@ -18,7 +18,7 @@
 #include "ow.h"
 #include "ow_connection.h"
 
-pthread_mutex_t persistence_mutex ;
+extern pthread_mutex_t persistence_mutex ;
 #define PERSISTENCELOCK    _MUTEX_LOCK(   persistence_mutex ) ;
 #define PERSISTENCEUNLOCK  _MUTEX_UNLOCK( persistence_mutex ) ;
 


### PR DESCRIPTION
Fixed compilation with -fno-common, which enabled in GCC 10 by default.
See https://bugs.gentoo.org/707438.