### PR TITLE
Disable osx build on Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@
 # - Linux: the Travis PHP installation does not work with swig3
 #   we install the standard bionic package php7.2 and direct
 #   config to use with the configure options listed in $CONFOPTS
+# - osx: disabled (due to very slow compilation and python2 problems)
 # - osx: we use the homebrew php. Note that on osx 'compiler: gcc' is
 #   an alias for 'compiler: clang'. Therefore we build only with clang.
 #
@@ -20,10 +21,11 @@ os:
 
 env: CONFOPTS="--with-phpconfig=/usr/bin/php-config7.2 --with-php=/usr/bin/php7.2"
 
-jobs:
-  include:
-    - os: osx
-      env:
+# Darwin is disabled
+# jobs:
+#   include:
+#     - os: osx
+#       env:
 
 
 addons:
@@ -39,12 +41,13 @@ addons:
     - swig3.0
     - uthash-dev
 
-  homebrew:
-    packages:
-    - check
-    - php
-    - swig
-    update: true
+# Darwin is disabled
+#  homebrew:
+#    packages:
+#    - check
+#    - php
+#    - swig
+#    update: true
 
 before_script:
 - ./bootstrap


### PR DESCRIPTION
Darwin on Travis-CI is very slow and hard to manage. Disable for now.