### PR TITLE
Remove all clean-generic targets

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -6,10 +6,6 @@ RPMDIR = ${HOME}/.rpm
 
 EXTRA_DIST = bootstrap
 
-clean-generic:
-
-	@RM@ -f *~ .*~
-
 preparerpm: dist
 
 	@ if @TEST@ -z "@RPMBUILD@" ; then \

--- a/module/owlib/src/c/Makefile.am
+++ b/module/owlib/src/c/Makefile.am
@@ -275,5 +275,4 @@ AM_CFLAGS = -I../include \
 #SRC:=$(OWLIB_SOURCE)
 #include $(abs_top_srcdir)/src/tools/lint/lint.mk
 #
-#clean-generic:
-#	@RM@ -f *~ .*~ *.lint *.lint.txt .#* *.bak
+

--- a/module/ownet/perl5/Makefile.am
+++ b/module/ownet/perl5/Makefile.am
@@ -20,7 +20,7 @@ endif
 #	$(MAKE) -C OWNet install DESTDIR="$(DESTDIR)"
 #	( cd OWNet; $(MAKE) ; $(MAKE) test; $(MAKE) install )
 
-clean-generic:
+clean-local:
 	if test -f OWNet/Makefile; then cd OWNet; $(MAKE) clean; fi
-	@RM@ -f OWNet/Makefile.old OWNet/Makefile
+	-@RM@ -f OWNet/Makefile.old OWNet/Makefile
 

--- a/module/owserver/src/c/Makefile.am
+++ b/module/owserver/src/c/Makefile.am
@@ -59,5 +59,3 @@ LDADD = -low ${PTHREAD_LIBS} ${LD_EXTRALIBS} ${OSLIBS}
 #SRC:=$(owserver_SOURCES)
 #include $(abs_top_srcdir)/src/tools/lint/lint.mk
 #
-#clean-generic:
-#	@RM@ -f *~ .*~ *.lint *.lint.txt .#* *.bak

--- a/src/include/Makefile.am
+++ b/src/include/Makefile.am
@@ -1,9 +1,6 @@
 owfsincludedir = ${prefix}/include
 nodist_owfsinclude_HEADERS = owfs_config.h
 
-clean-generic:
-	@RM@ -f *.o *.tmp *.cpp .*~ stamp-* lint_cmac.h lint_cppmac.h gcc-include-path.lnt size-options.lnt
-
 COMMON_GCC_OPTS:= $(COMMON_FLAGS) $(CPPFLAGS) -Wno-long-long
 # We want to enable 'long long' for the purpose of extracting the value of
 # 'sizeof(long long)'; see the 'size-options.lnt' target below.


### PR DESCRIPTION
'clean-generic' targets where abused for different pourposes: here we delete all references to them.

- target `clean-generic` is created by Automake, and should not be overwritten
- `make clean` and friends should delete only files created by `make`, see [clean heuristics](https://www.gnu.org/software/automake/manual/automake.html#Clean)