### PR TITLE
Add Support for DS2413 with Family Code 85

### DIFF
--- a/module/owlib/src/c/ow_2413.c
+++ b/module/owlib/src/c/ow_2413.c
@@ -39,6 +39,7 @@
 
 /* Changes
     7/2004 Extensive improvements based on input from Serg Oskin
+    1/2022 Add Family Code 85 (Chip marked 3A 2100H)
 */
 
 #include <config.h>
@@ -67,6 +68,8 @@ static struct filetype DS2413[] = {
 };
 
 DeviceEntryExtended(3A, DS2413, DEV_resume | DEV_ovdr, NO_GENERIC_READ, NO_GENERIC_WRITE);
+// Family Code 85 for 3A 2100H marked clones
+DeviceEntryExtendedSecondary(85, DS2413, DEV_resume | DEV_ovdr, NO_GENERIC_READ, NO_GENERIC_WRITE);
 
 #define _1W_PIO_ACCESS_READ 0xF5
 #define _1W_PIO_ACCESS_WRITE 0x5A

--- a/module/owlib/src/c/ow_tree.c
+++ b/module/owlib/src/c/ow_tree.c
@@ -134,6 +134,7 @@ void DeviceSort(void)
 	Device2Tree( & d_DS2408,         ePN_real);
 	Device2Tree( & d_DS2409,         ePN_real);
 	Device2Tree( & d_DS2413,         ePN_real);
+	Device2Tree( & d_DS2413_85,      ePN_real);
 	Device2Tree( & d_DS2415,         ePN_real);
 	Device2Tree( & d_DS2417,         ePN_real);
 	Device2Tree( & d_DS2423,         ePN_real);

--- a/module/owlib/src/include/ow_2413.h
+++ b/module/owlib/src/include/ow_2413.h
@@ -19,5 +19,6 @@
 /* ------- Structures ----------- */
 
 DeviceHeader(DS2413);
+DeviceHeader(DS2413_85);
 
 #endif							/* 2413 code */


### PR DESCRIPTION
This PR adds Support for DS2413 clones marked as `3A 2100H`. These clones work exactly like the original DS2413, except for the different family code.