### PR TITLE
Fix DS2404 reset missing end transaction

### DIFF
--- a/module/owlib/src/c/ow_2404.c
+++ b/module/owlib/src/c/ow_2404.c
@@ -375,6 +375,7 @@ static void OW_reset(struct parsedname *pn)
 {
 	struct transaction_log t[] = {
 		TRXN_RESET,
+		TRXN_END
 	};
 	BUS_transaction(t, pn) ;
 }


### PR DESCRIPTION
Without TRXN_END the BUS_transaction_nolock() function in ow_transaction.c ends up in an endless loop reading random memory

```
Transact type=13
  DEBUG: ow_tcp_read.c:(63) attempt 1 bytes Time: 5.000000 seconds
  DEBUG: ow_tcp_read.c:(113) read: 1 - 0 = 1
  DEBUG: ow_transaction.c:(208) reset = 0
  DEBUG: ow_transaction.c:(232) Transaction 13 returns 0

Transact type=-1137528240
  DEBUG: ow_transaction.c:(232) Transaction -1137528240 returns 0

Transact type=-1137524896
  DEBUG: ow_transaction.c:(232) Transaction -1137524896 returns 0

Transact type=-1137021952
  DEBUG: ow_transaction.c:(232) Transaction -1137021952 returns 0

Transact type=-629124352
  DEBUG: ow_transaction.c:(232) Transaction -629124352 returns 0

Transact type=-1137017504
  DEBUG: ow_transaction.c:(232) Transaction -1137017504 returns 0

Transact type=-1137520656
  DEBUG: ow_transaction.c:(232) Transaction -1137520656 returns 0
```

eventually leading to a crash.