### PR TITLE
Fix ds2450 pio OE/OC logic

### DIFF
--- a/module/owlib/src/c/ow_2450.c
+++ b/module/owlib/src/c/ow_2450.c
@@ -495,9 +495,9 @@ static GOOD_OR_BAD OW_w_pio( int pio, struct parsedname *pn)
 {
 	BYTE p[1];
 	RETURN_BAD_IF_BAD( OW_r_mem(p, 1, _ADDRESS_CONTROL_PAGE + 2 * pn->extension, pn) ) ;
-	p[0] |= _1W_2450_OE | _1W_2450_OC ;
+	p[0] &= ~(_1W_2450_OE | _1W_2450_OC);
 	if ( pio==0 ) {
-		p[0] &= ~_1W_2450_OC ;
+		p[0] |= _1W_2450_OE ;
 	}
 	return OW_w_mem(p, 1, _ADDRESS_CONTROL_PAGE + 2 * pn->extension, pn);
 }


### PR DESCRIPTION
DS2450 has two bits for PIO control: OE (Output Enable) and OC (Output Control), which encodes 4 states, while port can be only in two states: high impedance and shorted to GND (output low):

| OE | OC | State |
| -- | -- | -- |
| 0 | 0 | high impedance (power-on default) |
| 0 | 1 | high impedance |
| 1 | 0 | shorted to GND (output low) |
| 1 | 1 | high impedance |

Current version of OWFS switches between OE=1,OC=1 and OE=1,OC=0 (so never returns to default OE=0,OC=0).

In my microcontroller based device I extended possible port states to 4:

| OE | OC | State |
| -- | -- | -- |
| 0 | 0 | high impedance (power-on default) |
| 0 | 1 | weak pull-up to VCC |
| 1 | 0 | shorted to GND (output low) |
| 1 | 1 | shorted to VCC (output high) |

So I ask to modify OWFS logic to switch between OE=0,OC=0(power-on default) and OE=1,OC=0.
This will not affect original ds2450 devices.
