### PR TITLE
Add support for device discovery based on their family code

### DIFF
--- a/module/owlib/src/c/ow_dir.c
+++ b/module/owlib/src/c/ow_dir.c
@@ -644,6 +644,7 @@ static ZERO_OR_ERROR FS_realdir(void (*dirfunc) (void *, const struct parsedname
 	if (RootNotBranch(pn_whole_directory)) {
 		db.allocated = pn_whole_directory->selected_connection->last_root_devs;	// root dir estimated length
 	}
+	BYTE family_presence[SERIAL_NUMBER_FAMILY_CODE_OPTIONS] = {0};
 	while ( ret == search_good ) {
 		if (!ds.family || ds.sn[0] == ds.family) {
 			/* For devices not supporting family search algorithm
@@ -651,6 +652,8 @@ static ZERO_OR_ERROR FS_realdir(void (*dirfunc) (void *, const struct parsedname
 			 * belonging in the queried family.
 			 */
 			char dev[PROPERTY_LENGTH_ALIAS + 1];
+
+			family_presence[ds.sn[0]] = 1; /* Mark family code as present on the bus */
 
 			/* Add to device cache */
 			Cache_Add_Device(pn_whole_directory->selected_connection->index,ds.sn) ;
@@ -669,6 +672,20 @@ static ZERO_OR_ERROR FS_realdir(void (*dirfunc) (void *, const struct parsedname
 
 		ret = PossiblyLockedBusCall( BUS_next, &ds, pn_whole_directory) ;
 	} 
+
+	if (!ds.family) {
+		/* Do not show the directory if already in a family filtered directory */
+		for (int i = 0; i < SERIAL_NUMBER_FAMILY_CODE_OPTIONS; ++i) {
+			if (family_presence[i]) {
+				char name[10];
+				sprintf(name, "family.%.2x", i);
+				if ( FS_dir_plus(dirfunc, v, flags, pn_whole_directory, name) != 0 ) {
+					DirblobPoison(&db);
+					break ;
+				}
+			}
+		}
+	}
 
 	STATLOCK;
 	dir_main.entries += devices;

--- a/module/owlib/src/c/ow_ds1wm.c
+++ b/module/owlib/src/c/ow_ds1wm.c
@@ -275,7 +275,6 @@ static RESET_TYPE DS1WM_reset(const struct parsedname * pn)
 	}
 }
 
-#define SERIAL_NUMBER_BITS (8*SERIAL_NUMBER_SIZE)
 /* search = normal and alarm */
 static enum search_status DS1WM_next_both(struct device_search *ds, const struct parsedname *pn)
 {

--- a/module/owlib/src/c/ow_ds2482.c
+++ b/module/owlib/src/c/ow_ds2482.c
@@ -558,7 +558,9 @@ static enum search_status DS2482_next_both(struct device_search *ds, const struc
 	for (bit_number = 0; bit_number < SERIAL_NUMBER_BITS; ++bit_number) {
 		LEVEL_DEBUG("bit number %d", bit_number);
 		/* Set the direction bit */
-		if (bit_number < ds->LastDiscrepancy) {
+		if (ds->family && bit_number < SERIAL_NUMBER_FAMILY_CODE_BITS) {
+			search_direction = UT_getbit(&ds->family, bit_number);
+		} else if (bit_number < ds->LastDiscrepancy) {
 			search_direction = UT_getbit(ds->sn, bit_number);
 		} else {
 			search_direction = (bit_number == ds->LastDiscrepancy) ? 1 : 0;
@@ -572,8 +574,18 @@ static enum search_status DS2482_next_both(struct device_search *ds, const struc
 				/* No devices respond */
 				ds->LastDevice = 1;
 				return search_done;
+			} else if (ds->family
+				&& bit_number < SERIAL_NUMBER_FAMILY_CODE_BITS // Search on the family number
+				&& bits[0] != bits[1] // There is no search direction choice to be made
+				&& bits[0] != search_direction // The search is heading in the wrong direction
+				) {
+				/* If we are filtering down family specific devices
+				 * we stop if we are heading to the wrong direction
+				 */
+				ds->LastDevice = 1;
+				return search_done;
 			}
-		} else {				/* 0,0,0 */
+		} else if (!ds->family || bit_number >= SERIAL_NUMBER_FAMILY_CODE_BITS) { /* 0,0,0 */
 			last_zero = bit_number;
 		}
 		UT_setbit(ds->sn, bit_number, bits[2]);

--- a/module/owlib/src/c/ow_ds2482.c
+++ b/module/owlib/src/c/ow_ds2482.c
@@ -555,7 +555,7 @@ static enum search_status DS2482_next_both(struct device_search *ds, const struc
 		return search_error;
 	}
 	// loop to do the search
-	for (bit_number = 0; bit_number < 64; ++bit_number) {
+	for (bit_number = 0; bit_number < SERIAL_NUMBER_BITS; ++bit_number) {
 		LEVEL_DEBUG("bit number %d", bit_number);
 		/* Set the direction bit */
 		if (bit_number < ds->LastDiscrepancy) {
@@ -579,7 +579,7 @@ static enum search_status DS2482_next_both(struct device_search *ds, const struc
 		UT_setbit(ds->sn, bit_number, bits[2]);
 	}							// loop until through serial number bits
 
-	if (CRC8(ds->sn, SERIAL_NUMBER_SIZE) || (bit_number < 64) || (ds->sn[0] == 0)) {
+	if (CRC8(ds->sn, SERIAL_NUMBER_SIZE) || (bit_number < SERIAL_NUMBER_BITS) || (ds->sn[0] == 0)) {
 		/* Unsuccessful search or error -- possibly a device suddenly added */
 		return search_error;
 	}

--- a/module/owlib/src/c/ow_ds9097U.c
+++ b/module/owlib/src/c/ow_ds9097U.c
@@ -813,7 +813,6 @@ static RESET_TYPE DS2480_reset_once(struct connection_in * in)
 	}
 }
 
-#define SERIAL_NUMBER_BITS (8*SERIAL_NUMBER_SIZE)
 /* search = normal and alarm */
 static enum search_status DS2480_next_both(struct device_search *ds, const struct parsedname *pn)
 {

--- a/module/owlib/src/c/ow_ds9490.c
+++ b/module/owlib/src/c/ow_ds9490.c
@@ -803,7 +803,7 @@ static void SetupDiscrepancy(const struct device_search *ds, BYTE * discrepancy)
 	}
 
 	/* This could be more efficiently done than bit-setting, but probably wouldn't make a difference */
-	for (i = ds->LastDiscrepancy + 1; i < 64; i++) {
+	for (i = ds->LastDiscrepancy + 1; i < SERIAL_NUMBER_BITS; i++) {
 		UT_setbit(discrepancy, i, 0);
 	}
 }

--- a/module/owlib/src/c/ow_fake.c
+++ b/module/owlib/src/c/ow_fake.c
@@ -271,11 +271,13 @@ static enum search_status Fake_next_both(struct device_search *ds, const struct 
 		ds->LastDevice = 1;
 		return search_done;
 	}
-	if (DirblobGet(++ds->index, ds->sn, &(pn->selected_connection->master.fake.main))) {
-		ds->LastDevice = 1;
-		return search_done;
+	while (!DirblobGet(++ds->index, ds->sn, &(pn->selected_connection->master.fake.main))) {
+		if (!ds->family || ds->sn[0] == ds->family) {
+			return search_good;
+		}
 	}
-	return search_good;
+	ds->LastDevice = 1;
+	return search_done;
 }
 
 /* Need to lock struct global_namefind_struct since twalk requires global data -- can't pass void pointer */

--- a/module/owlib/src/c/ow_k1wm.c
+++ b/module/owlib/src/c/ow_k1wm.c
@@ -244,7 +244,6 @@ static RESET_TYPE K1WM_reset(const struct parsedname * pn)
 	}
 }
 
-#define SERIAL_NUMBER_BITS (8*SERIAL_NUMBER_SIZE)
 /* search = normal and alarm */
 static enum search_status K1WM_next_both(struct device_search *ds, const struct parsedname *pn)
 {

--- a/module/owlib/src/c/ow_search.c
+++ b/module/owlib/src/c/ow_search.c
@@ -188,7 +188,7 @@ enum search_status BUS_next_both_bitbang(struct device_search *ds, const struct 
 				}
 			} else {
 				bits[0] = search_direction;
-				if (bit_number < 64) {
+				if (bit_number < SERIAL_NUMBER_BITS) {
 					/* Send chosen bit path, then check match on next two */
 					if ( BAD( BUS_sendback_bits(bits, bits, 3, pn) ) ) {
 						return search_error;
@@ -229,7 +229,7 @@ enum search_status BUS_next_both_bitbang(struct device_search *ds, const struct 
 			
 		}	// loop until through serial number bits
 		
-		if ( (CRC8(ds->sn, SERIAL_NUMBER_SIZE)!=0) || (bit_number < 64) || (ds->sn[0] == 0)) {
+		if ( (CRC8(ds->sn, SERIAL_NUMBER_SIZE)!=0) || (bit_number < SERIAL_NUMBER_BITS) || (ds->sn[0] == 0)) {
 			/* A minor "error" */
 			return search_error;
 		}

--- a/module/owlib/src/c/ow_verify.c
+++ b/module/owlib/src/c/ow_verify.c
@@ -37,7 +37,7 @@ GOOD_OR_BAD BUS_verify(BYTE search, const struct parsedname *pn)
 	buffer[0] = search;
 
 	// now set or clear apropriate bits for search
-	for (i = 0; i < 64; i++) {
+	for (i = 0; i < SERIAL_NUMBER_BITS; i++) {
 		UT_setbit(buffer, 3 * i + 10, UT_getbit(pn->sn, i));
 	}
 
@@ -47,7 +47,7 @@ GOOD_OR_BAD BUS_verify(BYTE search, const struct parsedname *pn)
 	if (buffer[0] != search) {
 		return gbBAD;
 	}
-	for (i = 0; (i < 64) && (goodbits < 64); i++) {
+	for (i = 0; (i < SERIAL_NUMBER_BITS) && (goodbits < SERIAL_NUMBER_BITS); i++) {
 		switch (UT_getbit(buffer, 3 * i + 8) << 1 | UT_getbit(buffer, 3 * i + 9)) {
 		case 0:
 			break;

--- a/module/owlib/src/include/ow.h
+++ b/module/owlib/src/include/ow.h
@@ -242,9 +242,11 @@ time_t timegm(struct tm *tm);
 #endif							/* ENOTSUP */
 
 /* Bytes in a 1-wire address */
-#define SERIAL_NUMBER_SIZE           8
+#define SERIAL_NUMBER_SIZE             8
 /* Bits in a 1-wire address */
-#define SERIAL_NUMBER_BITS           (8*SERIAL_NUMBER_SIZE)
+#define SERIAL_NUMBER_BITS             (8*SERIAL_NUMBER_SIZE)
+/* Bits in a 1-wire address used for the family code of the device */
+#define SERIAL_NUMBER_FAMILY_CODE_BITS 8
 
 /* Allocation wrappers for debugging */
 #include "ow_alloc.h"

--- a/module/owlib/src/include/ow.h
+++ b/module/owlib/src/include/ow.h
@@ -243,6 +243,8 @@ time_t timegm(struct tm *tm);
 
 /* Bytes in a 1-wire address */
 #define SERIAL_NUMBER_SIZE           8
+/* Bits in a 1-wire address */
+#define SERIAL_NUMBER_BITS           (8*SERIAL_NUMBER_SIZE)
 
 /* Allocation wrappers for debugging */
 #include "ow_alloc.h"

--- a/module/owlib/src/include/ow.h
+++ b/module/owlib/src/include/ow.h
@@ -242,11 +242,13 @@ time_t timegm(struct tm *tm);
 #endif							/* ENOTSUP */
 
 /* Bytes in a 1-wire address */
-#define SERIAL_NUMBER_SIZE             8
+#define SERIAL_NUMBER_SIZE                8
 /* Bits in a 1-wire address */
-#define SERIAL_NUMBER_BITS             (8*SERIAL_NUMBER_SIZE)
+#define SERIAL_NUMBER_BITS                (8*SERIAL_NUMBER_SIZE)
 /* Bits in a 1-wire address used for the family code of the device */
-#define SERIAL_NUMBER_FAMILY_CODE_BITS 8
+#define SERIAL_NUMBER_FAMILY_CODE_BITS    8
+/* Number of family code available for a 1-wire address */
+#define SERIAL_NUMBER_FAMILY_CODE_OPTIONS (1 << SERIAL_NUMBER_FAMILY_CODE_BITS)
 
 /* Allocation wrappers for debugging */
 #include "ow_alloc.h"

--- a/module/owlib/src/include/ow_parsedname.h
+++ b/module/owlib/src/include/ow_parsedname.h
@@ -123,6 +123,7 @@ enum ePS_state {
 	ePS_reconnection  = 0x0100,
 	ePS_unaliased     = 0x0200,
 	ePS_json          = 0x0400,
+	ePS_family        = 0x0800,
 };
 
 struct parsedname {
@@ -132,6 +133,7 @@ struct parsedname {
 	struct connection_in *known_bus;	// where this device is located
 	enum ePN_type type;			// real? settings? ...
 	enum ePS_state state;			// alarm?
+	BYTE family;				// 1 byte family filter
 	BYTE sn[SERIAL_NUMBER_SIZE];				// 64-bit serial number
 	struct device *selected_device;		// 1-wire device
 	struct filetype *selected_filetype;	// device property
@@ -207,6 +209,8 @@ struct parsedname {
 #define SpecifiedLocalBus(pn)          ((((pn)->state) & ePS_buslocal) != 0 )
 
 #define SpecifiedBus(pn)          ( SpecifiedLocalBus(pn) || SpecifiedRemoteBus(pn) )
+
+#define SpecifiedFamily(pn)   ((((pn)->state) & ePS_family) != 0 )
 
 #define RootNotBranch(pn)         (((pn)->ds2409_depth)==0)
 

--- a/module/owlib/src/include/ow_search.h
+++ b/module/owlib/src/include/ow_search.h
@@ -60,6 +60,7 @@ struct device_search {
 	int LastDevice;				// for search
 	int index;
 	BYTE sn[SERIAL_NUMBER_SIZE];
+	BYTE family;
 	BYTE search;
 
 	// For adapters that maintain dir-at-once (or dirgulp):


### PR DESCRIPTION
This pull request add the support of filtering 1-wire devices based on their family code. Each 1-wire slave-device has their own 64bits serial number. The first 8 bits of that serial number is used to define the family of the device (temperature sensor, button, eprom, ...).
The 1-wire [search algorithm](https://www.analog.com/en/resources/app-notes/1wire-search-algorithm.html) is in essence a binary tree traversal. If multiple 1-wire devices share the same bus it's possible to speed up the discovery of a specific family code by forcing the direction the algorithm takes for the first 8 bits. This is especially useful for the discovery of devices that requires probing the bus (family `0x01`).

This PR adds a new type of path you can query in owlib: the `family.XX` path that will only retrieve the devices of the family type `0xXX`. For instance the following directory tree now exists:

```
/bus.0/uncached/bus.6/
  |
  +- 01.4AEC29CDBAAB/
  +- 01.54F81BE8E78D/
  +- 01.765A2E63339F/
  +- 10.67C6697351FF/
  +- 2A.C99A66320DB7/
  +- family.01/
  |  |
  |  +- 01.4AEC29CDBAAB/
  |  +- 01.54F81BE8E78D/
  |  +- 01.765A2E63339F/
  |
  +- family.10/
  |  |
  |  +- 10.67C6697351FF/
  |
  +- family.2A/
     |
     +- 2A.C99A66320DB7/
```

This PR supports the following backends but more could added:
  - Fake device
  - bitbang
  - DS2482
However, unsupported backends will benefit from the same query but won't benefit from a speed up with the discovery of the devices.

This PR fix the issue https://github.com/owfs/owfs/issues/111