### PR TITLE
python3 support for swig & ownet

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,13 +5,12 @@ on:
   pull_request:
 
 jobs:
-
   build:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, ubuntu-20.04, macos-12]
+        os: [ubuntu-22.04, ubuntu-20.04]
     steps:
     - uses: actions/checkout@v2
     - name: Setup PHP
@@ -19,15 +18,26 @@ jobs:
       with:
           php-version: "7.4"
     - name: install dependencies on Linux
-      if: runner.os == 'Linux'
       run: sudo apt-get update && sudo apt-get install -y libfuse-dev swig uthash-dev tcl-dev python3-dev libftdi1-dev libavahi-client-dev check
-    - name: install dependendencies on macOS
-      if: runner.os == 'macOs'
-      run: brew install autoconf automake libtool pkg-config swig libftdi check && python3 -m pip install setuptools
     - name: bootstrap
       run: ./bootstrap
     - name: configure
       run: ./configure
+    - name: make
+      run: make
+    - name: check
+      run: make check
+
+  build-mac:
+    runs-on: macos-12
+    steps:
+    - uses: actions/checkout@v2
+    - name: install dependendencies on macOS
+      run: brew install autoconf automake libtool pkg-config swig libftdi check && python3 -m pip install setuptools
+    - name: bootstrap
+      run: ./bootstrap
+    - name: configure
+      run: ./configure --disable-owphp --without-php
     - name: make
       run: make
     - name: check

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,32 +11,23 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-18.04, ubuntu-20.04, macos-10.15, macos-11]
-        cc: [""]
-        include:
-        # gcc-10 on ubuntu-20.04
-        - os: ubuntu-20.04
-          cc: CC=/usr/bin/gcc-10
-          setup: sudo apt-get install -y gcc-10
+        os: [ubuntu-22.04, ubuntu-20.04, macos-12]
     steps:
     - uses: actions/checkout@v2
-    - name: setup
-      if: ${{ matrix.setup }}
-      run: ${{ matrix.setup }}
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
       with:
           php-version: "7.4"
     - name: install dependencies on Linux
       if: runner.os == 'Linux'
-      run: sudo apt-get install -y libfuse-dev swig uthash-dev tcl-dev python-dev libftdi1-dev libavahi-client-dev check
+      run: sudo apt-get update && sudo apt-get install -y libfuse-dev swig uthash-dev tcl-dev python3-dev libftdi1-dev libavahi-client-dev check
     - name: install dependendencies on macOS
       if: runner.os == 'macOs'
-      run: brew install autoconf automake libtool pkg-config swig libftdi check
+      run: brew install autoconf automake libtool pkg-config swig libftdi check && python3 -m pip install setuptools
     - name: bootstrap
       run: ./bootstrap
     - name: configure
-      run: ${{ matrix.cc }} ./configure
+      run: ./configure
     - name: make
       run: make
     - name: check
@@ -71,7 +62,7 @@ jobs:
           php-version: "7.4"
     - name: install dependencies on Linux
       if: runner.os == 'Linux'
-      run: sudo apt-get install -y libfuse-dev swig uthash-dev tcl-dev python-dev libftdi1-dev libavahi-client-dev check
+      run: sudo apt-get update && sudo apt-get install -y libfuse-dev swig uthash-dev tcl-dev python3-dev libftdi1-dev libavahi-client-dev check
     - uses: actions/download-artifact@v2
       with:
         name: source-dist

--- a/module/ownet/python/examples/check_ow.py
+++ b/module/ownet/python/examples/check_ow.py
@@ -41,10 +41,10 @@ path   = args[2]
 
 try:
     s = ownet.Sensor(path, server=server, port=port)
-except ownet.exUnknownSensor, ex:
+except ownet.exUnknownSensor as ex:
     print 'OW ' + nagios.unknown[1] + ' - unknown sensor ' + str(ex)
     sys.exit(nagios.unknown[0])
-except socket.error, ex:
+except socket.error as ex:
     print 'OW ' + nagios.unknown[1] + ' - communication error ' + str(ex)
     sys.exit(nagios.unknown[0])
 

--- a/module/ownet/python/examples/check_ow.py
+++ b/module/ownet/python/examples/check_ow.py
@@ -24,14 +24,14 @@ class nagios:
 # FIXME: need to add more help text in the init_string and sensor_path parameters
 parser = OptionParser(usage='usage: %prog [options] server port sensor_path',
                       version='%prog ' + ownet.__version__)
-parser.add_option('-v', dest='verbose', action='count',             help='multiple -v increases the level of debugging output.')
-parser.add_option('-w', dest='warning',                 type='int', help='warning level.')
-parser.add_option('-c', dest='critical',                type='int', help='critical level.')
+parser.add_option('-v', dest='verbose', action='count',             help='multiple -v increases the level of debugging output.', default=0)
+parser.add_option('-w', dest='warning',                 type='int', help='warning level.', default=0)
+parser.add_option('-c', dest='critical',                type='int', help='critical level.', default=0)
 parser.add_option('-f', dest='field',                               help='sensor field to be used for monitoring.', default='temperature')
 options, args = parser.parse_args()
 
 if len(args) != 3:
-    print 'OW ' + nagios.unknown[1] + ' - ' + 'missing command line arguments'
+    print('OW ' + nagios.unknown[1] + ' - ' + 'missing command line arguments')
     parser.print_help()
     sys.exit(nagios.unknown[0])
 
@@ -42,21 +42,21 @@ path   = args[2]
 try:
     s = ownet.Sensor(path, server=server, port=port)
 except ownet.exUnknownSensor as ex:
-    print 'OW ' + nagios.unknown[1] + ' - unknown sensor ' + str(ex)
+    print('OW ' + nagios.unknown[1] + ' - unknown sensor ' + str(ex))
     sys.exit(nagios.unknown[0])
 except socket.error as ex:
-    print 'OW ' + nagios.unknown[1] + ' - communication error ' + str(ex)
+    print('OW ' + nagios.unknown[1] + ' - communication error ' + str(ex))
     sys.exit(nagios.unknown[0])
 
 if options.verbose == 1:
-    print s
+    print(s)
 elif options.verbose > 1:
-    print s
-    print 'entryList:', s.entryList()
-    print 'sensorList:', s.sensorList()
+    print(s)
+    print('entryList:', s.entryList())
+    print('sensorList:', s.sensorList())
 
 if not hasattr(s, options.field):
-    print 'OW ' + nagios.unknown[1] + ' - ' + 'unknown field: ' + options.field
+    print('OW ' + nagios.unknown[1] + ' - ' + 'unknown field: ' + options.field)
     sys.exit(nagios.unknown[0])
 
 val = getattr(s, options.field)
@@ -71,5 +71,5 @@ else:
     status    = nagios.ok[1]
     exit_code = nagios.ok[0]
 
-print 'OW %s - %s %s: %i| %s/%s=%i' % (status, path, options.field, val, path, options.field, val)
+print('OW %s - %s %s: %i| %s/%s=%i' % (status, path, options.field, val, path, options.field, val))
 sys.exit(exit_code)

--- a/module/ownet/python/examples/temperatures.py
+++ b/module/ownet/python/examples/temperatures.py
@@ -4,16 +4,16 @@ import sys
 import ownet
 
 if len(sys.argv) != 3:
-    print 'temperatures.py server port'
+    print('temperatures.py server port')
     sys.exit(1)
 
 r = ownet.Sensor('/', server=sys.argv[1], port=int(sys.argv[2]))
 e = r.entryList()
 s = r.sensorList()
-print 'r:', r
-print 'r.entryList():', e
-print 'r.sensorList():', s
+print('r:', r)
+print('r.entryList():', e)
+print('r.sensorList():', s)
 
 for x in r.sensors():
     if hasattr(x, 'temperature'):
-        print x, x.temperature
+        print(x, x.temperature)

--- a/module/ownet/python/ownet/__init__.py
+++ b/module/ownet/python/ownet/__init__.py
@@ -248,7 +248,7 @@ class Sensor(object):
             #print 'Sensor.__getattr__(%s)' % name
             attr = self._connection.read(object.__getattribute__(self, '_attrs')[name])
         except:
-            raise AttributeError, name
+            raise AttributeError(name)
 
         return attr
 
@@ -379,7 +379,7 @@ class Sensor(object):
                         # print 'branch_entry(%s)' % str(branch_entry)
                         try:
                             self._connection.read(branch_entry + '/type')
-                        except exUnknownSensor, ex:
+                        except exUnknownSensor as ex:
                             continue
                         yield Sensor(branch_entry, connection=self._connection)
 

--- a/module/ownet/python/ownet/__init__.py
+++ b/module/ownet/python/ownet/__init__.py
@@ -31,7 +31,7 @@ from __future__ import generators
 
 import sys
 import os
-from connection import Connection
+from ownet.connection import Connection
 
 __author__ = 'Peter Kropf'
 __email__ = 'pkropf@gmail.com'
@@ -379,7 +379,7 @@ class Sensor(object):
                         # print 'branch_entry(%s)' % str(branch_entry)
                         try:
                             self._connection.read(branch_entry + '/type')
-                        except exUnknownSensor as ex:
+                        except exUnknownSensor:
                             continue
                         yield Sensor(branch_entry, connection=self._connection)
 

--- a/module/ownet/python/ownet/connection.py
+++ b/module/ownet/python/ownet/connection.py
@@ -28,6 +28,7 @@ import os
 import socket
 import struct
 import re
+from six import ensure_binary, ensure_str
 
 
 __author__ = 'Peter Kropf'
@@ -124,7 +125,7 @@ class Connection(object):
 
         smsg = self.pack(OWMsg.read, len(path) + 1, 8192)
         s.sendall(smsg)
-        s.sendall(path + '\x00')
+        s.sendall(ensure_binary(path + '\x00'))
 
         while 1:
             data = s.recv(24)
@@ -136,7 +137,7 @@ class Connection(object):
 
             if payload_len >= 0:
                 data = s.recv(payload_len)
-                rtn = self.toNumber(data[:data_len])
+                rtn = self.toNumber(ensure_str(data[:data_len]))
                 break
             else:
                 # ping response
@@ -158,7 +159,7 @@ class Connection(object):
         value = str(value)
         smsg = self.pack(OWMsg.write, len(path) + 1 + len(value) + 1, len(value) + 1)
         s.sendall(smsg)
-        s.sendall(path + '\x00' + value + '\x00')
+        s.sendall(ensure_binary(path + '\x00' + value + '\x00'))
 
         data = s.recv(24)
 
@@ -181,7 +182,7 @@ class Connection(object):
 
         smsg = self.pack(OWMsg.dir, len(path) + 1, 0)
         s.sendall(smsg)
-        s.sendall(path + '\x00')
+        s.sendall(ensure_binary(path + '\x00'))
 
         fields = []
         while 1:
@@ -194,7 +195,7 @@ class Connection(object):
 
             if payload_len > 0:
                 data = s.recv(payload_len)
-                fields.append(data[:data_len])
+                fields.append(ensure_str(data[:data_len]))
             else:
                 # end of dir list or 'ping' response
                 break

--- a/module/ownet/python/ownet/connection.py
+++ b/module/ownet/python/ownet/connection.py
@@ -224,7 +224,7 @@ class Connection(object):
 
         #print 'Connection.unpack("%s")' % msg
         if len(msg) is not 24:
-            raise exInvalidMessage, msg
+            raise exInvalidMessage(msg)
 
         val          = struct.unpack('iiiiii', msg)
         version      = socket.ntohl(val[0])

--- a/module/ownet/ruby/sensor.rb
+++ b/module/ownet/ruby/sensor.rb
@@ -51,17 +51,17 @@ module OWNet
         if @attrs.include? name
           @connection.read(@attrs[name])
         else
-          raise AttributeError, name
+          raise AttributeError(name)
         end
       elsif name[-1] == "="[0] and args.size == 1
         name = name.to_s[0..-2]
         if @attrs.include? name
           @connection.write(@attrs[name], args[0])
         else
-          raise AttributeError, name
+          raise AttributeError(name)
         end
       else
-        raise NoMethodError, "undefined method \"#{name}\" for #{self}:#{self.class}"
+        raise NoMethodError("undefined method \"#{name}\" for #{self}:#{self.class}")
       end
     end
     

--- a/module/swig/python/examples/check_ow.py
+++ b/module/swig/python/examples/check_ow.py
@@ -59,7 +59,7 @@ if options.temperature:
 try:
     ow.error_print(ow.error_print.suppressed) # needed to exclude debug output which confuses nagios
     ow.init(init)
-except ow.exUnknownSensor, ex:
+except ow.exUnknownSensor as ex:
     exit(nagios.unknown[0], 'unable to initialize sensor adapter ' + str(ex))
 
 
@@ -72,7 +72,7 @@ else:
 
 try:
     s = ow.Sensor(sensor)
-except ow.exUnknownSensor, ex:
+except ow.exUnknownSensor as ex:
     exit(nagios.unknown, 'unknown sensor ' + str(ex))
 
 

--- a/module/swig/python/examples/check_ow.py
+++ b/module/swig/python/examples/check_ow.py
@@ -34,7 +34,7 @@ class nagios:
 
 
 def exit(status, message):
-    print 'ow ' + status[1] + ' - ' + message
+    print('ow ' + status[1] + ' - ' + message)
     sys.exit(status[0])
 
 
@@ -77,11 +77,11 @@ except ow.exUnknownSensor as ex:
 
 
 if options.verbose == 1:
-    print s
+    print(s)
 elif options.verbose > 1:
-    print s
-    print 'entryList:', s.entryList()
-    print 'sensorList:', s.sensorList()
+    print(s)
+    print('entryList:', s.entryList())
+    print('sensorList:', s.sensorList())
 
 if len(pieces) > 1:
     field = pieces[1]
@@ -89,16 +89,16 @@ if len(pieces) > 1:
     try:
         v = float(getattr(s, field))
     except AttributeError:
-	    exit(nagios.unknown, 'unknown field - ' + repr(s) + '.' + field)
+        exit(nagios.unknown, 'unknown field - ' + repr(s) + '.' + field)
 
     if options.critical:
         if v > options.critical:
             exit(nagios.critical, repr(s) + '.' + field + ' %f' % v)
-	
+
     if options.warning:
         if v > options.warning:
             exit(nagios.warning, repr(s) + '.' + field + ' %f' % v)
-	
+
     exit(nagios.ok, repr(s) + '.' + field + ' %f' % v)
 
 else: # len(pieces) > 1

--- a/module/swig/python/examples/errormessages.py
+++ b/module/swig/python/examples/errormessages.py
@@ -30,17 +30,17 @@ import ow
 
 
 def tree( sensor ):
-    print '%7s - %s' % ( sensor._type, sensor._path )
+    print('%7s - %s' % ( sensor._type, sensor._path ))
     for next in sensor.sensors( ):
         if next._type in [ 'DS2409', ]:
             tree( next )
         else:
-            print '%7s - %s' % ( next._type, next._path )
+            print('%7s - %s' % ( next._type, next._path ))
 
 
 if __name__ == "__main__":
     if len( sys.argv ) == 1:
-        print 'usage: errormessages.py u|serial_port_path'
+        print('usage: errormessages.py u|serial_port_path')
         sys.exit( 1 )
     else:
         # Turn on the level of message to display

--- a/module/swig/python/examples/raw_access.py
+++ b/module/swig/python/examples/raw_access.py
@@ -33,19 +33,19 @@ def tree( path, indent = 0 ):
     if raw:
         entries = raw.split( ',' )
         for entry in entries:
-            print ' ' * indent, entry
+            print(' ' * indent, entry)
             if entry[ -1 ] == '/':
                 tree( entry, indent + 4 )
 
 
 if __name__ == "__main__":
     if len( sys.argv ) == 1:
-        print 'usage: tree.py u|serial_port_path|localhost:4304'
+        print('usage: tree.py u|serial_port_path|localhost:4304')
         sys.exit( 1 )
     else:
         if not _OW.init( sys.argv[ 1 ] ):
-	    print 'problem initializing the 1-wire controller'
-	    sys.exit( 1 )
+            print('problem initializing the 1-wire controller')
+            sys.exit( 1 )
 
 
 tree( '/' )

--- a/module/swig/python/examples/temperature.py
+++ b/module/swig/python/examples/temperature.py
@@ -32,12 +32,13 @@ import ow
 def temperature( ):
     root = ow.Sensor( '/' )
     for sensor in root.find( type = 'DS18S20' ):
-        print sensor._path, sensor.temperature
+        print(sensor)
+        print(sensor._path, sensor.temperature)
 
 
 if __name__ == "__main__":
     if len( sys.argv ) == 1:
-        print 'usage: temperature.py u|serial_port_path'
+        print('usage: temperature.py u|serial_port_path')
         sys.exit( 1 )
     else:
         ow.init( sys.argv[ 1 ] )

--- a/module/swig/python/examples/tree.py
+++ b/module/swig/python/examples/tree.py
@@ -29,17 +29,17 @@ import ow
 
 
 def tree( sensor ):
-    print '%7s - %s' % ( sensor._type, sensor._path )
+    print('%7s - %s' % ( sensor._type, sensor._path ))
     for next in sensor.sensors( ):
         if next._type in [ 'DS2409', ]:
             tree( next )
         else:
-            print '%7s - %s' % ( next._type, next._path )
+            print('%7s - %s' % ( next._type, next._path ))
 
 
 if __name__ == "__main__":
     if len( sys.argv ) == 1:
-        print 'usage: tree.py u|serial_port_path|localhost:4304'
+        print('usage: tree.py u|serial_port_path|localhost:4304')
         sys.exit( 1 )
     else:
         ow.init( sys.argv[ 1 ] )

--- a/module/swig/python/examples/xmlrpc_client.py
+++ b/module/swig/python/examples/xmlrpc_client.py
@@ -24,18 +24,17 @@ Create an XML-RPC client for a 1-wire network.
 """
 
 
-import xmlrpclib
-import code
+from xmlrpc.client import ServerProxy
 
 
-ow_sensor = xmlrpclib.ServerProxy( 'http://localhost:8765/' )
-print 'Entries at the root:', ow_sensor.entries( '/' )
+ow_sensor = ServerProxy( 'http://localhost:8765/' )
+print('Entries at the root:', ow_sensor.entries( '/' ))
 
-print 'List of sensors:'
+print('List of sensors:')
 sensors = ow_sensor.sensors( '/' )
 for sensor in sensors:
     sensor_type = ow_sensor.attr( sensor, 'type' )
     if sensor_type == 'DS18S20':
-        print '   ', sensor, '-', sensor_type, '- temperature:', ow_sensor.attr( sensor, 'temperature' ).strip( )
+        print('   ', sensor, '-', sensor_type, '- temperature:', ow_sensor.attr( sensor, 'temperature' ).strip( ))
     else:
-        print '   ', sensor, '-', sensor_type
+        print('   ', sensor, '-', sensor_type)

--- a/module/swig/python/examples/xmlrpc_server.py
+++ b/module/swig/python/examples/xmlrpc_server.py
@@ -30,8 +30,8 @@ Or point a browser at http://localhost:8765 to see some documentation.
 
 import sys
 import ow
-from DocXMLRPCServer import DocXMLRPCServer, DocXMLRPCRequestHandler
-from SocketServer import ThreadingMixIn
+from xmlrpc.server import DocXMLRPCServer, DocXMLRPCRequestHandler
+from socketserver import ThreadingMixIn
 
 
 class owr:
@@ -54,7 +54,7 @@ class owr:
     def attr( self, path, attr ):
         """Lookup a specific sensor attribute."""
         sensor = ow.Sensor( path )
-        exec 'val = sensor.' + attr
+        val = getattr(sensor, attr)
         return val
 
 
@@ -62,15 +62,19 @@ class ThreadingServer( ThreadingMixIn, DocXMLRPCServer ):
     pass
 
 
-# Initialize ow for a USB controller or for a serial port.
-ow.init( 'u' )
-#ow.init( '/dev/ttyS0' )
+if __name__ == "__main__":
+    if len( sys.argv ) == 1:
+        print('usage: errormessages.py u|serial_port_path|address')
+        sys.exit( 1 )
+    else:
+        # Initialize ow
+        ow.init( sys.argv[1] )
 
-# Allow connections for the localhost on port 8765.
-serveraddr = ( '', 8765 )
-srvr = ThreadingServer( serveraddr, DocXMLRPCRequestHandler )
-srvr.set_server_title( '1-wire network' )
-srvr.set_server_documentation( 'Welcome to the world of 1-wire networks.' )
-srvr.register_instance( owr( ) )
-srvr.register_introspection_functions( )
-srvr.serve_forever( )
+        # Allow connections for the localhost on port 8765.
+        serveraddr = ( '', 8765 )
+        srvr = ThreadingServer( serveraddr, DocXMLRPCRequestHandler )
+        srvr.set_server_title( '1-wire network' )
+        srvr.set_server_documentation( 'Welcome to the world of 1-wire networks.' )
+        srvr.register_instance( owr( ) )
+        srvr.register_introspection_functions( )
+        srvr.serve_forever( )

--- a/module/swig/python/ow/__init__.py
+++ b/module/swig/python/ow/__init__.py
@@ -424,7 +424,7 @@ class Sensor( object ):
             for entry in list.split( ',' ):
                 try:
                     owfs_get(entry + 'type')
-                except exUnknownSensor as ex:
+                except exUnknownSensor:
                     yield entry.split( '/' )[ 0 ]
 
 
@@ -464,14 +464,14 @@ class Sensor( object ):
                 path = self._usePath + '/' + branch
                 try:
                     list = owfs_get( path )
-                except exUnknownSensor as ex:
+                except exUnknownSensor:
                     continue
                 if list:
                     for branch_entry in list.split( ',' ):
                         branch_path = self._usePath + '/' + branch + '/' + branch_entry.split( '/' )[ 0 ]
                         try:
                             owfs_get( branch_path + '/type' )
-                        except exUnknownSensor as ex:
+                        except exUnknownSensor:
                             continue
                         yield Sensor( branch_path )
 
@@ -481,7 +481,7 @@ class Sensor( object ):
                 for branch_entry in list.split( ',' ):
                     try:
                         owfs_get( branch_entry + 'type' )
-                    except exUnknownSensor as ex:
+                    except exUnknownSensor:
                         continue
                     path = self._usePath + '/' + branch_entry.split( '/' )[ 0 ]
                     if path[ :2 ] == '//':

--- a/module/swig/python/ow/__init__.py
+++ b/module/swig/python/ow/__init__.py
@@ -343,7 +343,7 @@ class Sensor( object ):
         try:
             return owfs_get(object.__getattribute__(self, '_attrs')[name])
         except KeyError:
-            raise AttributeError, name
+            raise AttributeError(name)
 
 
     def __setattr__( self, name, value ):
@@ -424,7 +424,7 @@ class Sensor( object ):
             for entry in list.split( ',' ):
                 try:
                     owfs_get(entry + 'type')
-                except exUnknownSensor, ex:
+                except exUnknownSensor as ex:
                     yield entry.split( '/' )[ 0 ]
 
 
@@ -464,14 +464,14 @@ class Sensor( object ):
                 path = self._usePath + '/' + branch
                 try:
                     list = owfs_get( path )
-                except exUnknownSensor, ex:
+                except exUnknownSensor as ex:
                     continue
                 if list:
                     for branch_entry in list.split( ',' ):
                         branch_path = self._usePath + '/' + branch + '/' + branch_entry.split( '/' )[ 0 ]
                         try:
                             owfs_get( branch_path + '/type' )
-                        except exUnknownSensor, ex:
+                        except exUnknownSensor as ex:
                             continue
                         yield Sensor( branch_path )
 
@@ -481,7 +481,7 @@ class Sensor( object ):
                 for branch_entry in list.split( ',' ):
                     try:
                         owfs_get( branch_entry + 'type' )
-                    except exUnknownSensor, ex:
+                    except exUnknownSensor as ex:
                         continue
                     path = self._usePath + '/' + branch_entry.split( '/' )[ 0 ]
                     if path[ :2 ] == '//':

--- a/module/swig/python/python.m4
+++ b/module/swig/python/python.m4
@@ -32,7 +32,7 @@ AC_ARG_WITH(python, [  --with-python           Set location of Python executable
 AC_ARG_WITH(pythonconfig, [  --with-pythonconfig        Set location of python-config executable],[ PYTHONCONFIGBIN="$withval"], [PYTHONCONFIGBIN=yes])
 
 if test "x$PYTHONCONFIGBIN" = xyes; then
-       AC_CHECK_PROGS(PYTHONCONFIG, python-config python2.7-config python2.5-config python2.4-config python2.3-config)
+       AC_CHECK_PROGS(PYTHONCONFIG, python-config python3.12-config python3.11-config python3.10-config python3.9-config python3.8-config)
 else
       PYTHONCONFIG="$PYTHONCONFIGBIN"
 fi
@@ -44,7 +44,7 @@ else
 # First figure out the name of the Python executable
 
 if test "x$PYBIN" = xyes; then
-AC_CHECK_PROGS(PYTHON, python python2.7 python2.5 python2.4 python2.3 python2.2 python2.1 python2.0 python1.6 python1.5 python1.4 python)
+AC_CHECK_PROGS(PYTHON, python python3.12 python3.11 python3.10 python3.9 python3.8)
 else
 PYTHON="$PYBIN"
 fi
@@ -82,7 +82,7 @@ if test ! -z "$PYTHONCONFIG"; then
 
    # Need to do this hack since autoconf replaces __file__ with the name of the configure file
    filehack="file__"
-   PYVERSION=`($PYTHON -c "import string,operator,os.path; print operator.getitem(os.path.split(operator.getitem(os.path.split(string.__$filehack),0)),1)")`
+   PYVERSION=`($PYTHON -c "import string,operator,os.path; print(operator.getitem(os.path.split(operator.getitem(os.path.split(string.__$filehack),0)),1))")`
    AC_MSG_RESULT($PYVERSION)
 
    AC_MSG_CHECKING(for Python exec-prefix)
@@ -96,7 +96,7 @@ if test ! -z "$PYTHONCONFIG"; then
 
    AC_MSG_CHECKING(for Python site-dir)
    #This seem to be the site-packages dir where files are installed.
-   PYSITEDIR=`($PYTHON -c "from distutils.sysconfig import get_python_lib; print get_python_lib(plat_specific=1)") 2>/dev/null`
+   PYSITEDIR=`($PYTHON -c "from distutils.sysconfig import get_python_lib; print(get_python_lib(plat_specific=1))") 2>/dev/null`
    if test -z "$PYSITEDIR"; then
      # I'm not really sure if it should be installed at /usr/lib64...
      if test -d "$PYEPREFIX/lib$LIBPOSTFIX/$PYVERSION/site-packages"; then
@@ -114,10 +114,10 @@ else
 # python-config not available.
 if test -n "$PYTHON"; then
     AC_MSG_CHECKING(for Python prefix)
-    PYPREFIX=`($PYTHON -c "import sys; print sys.prefix") 2>/dev/null`
+    PYPREFIX=`($PYTHON -c "import sys; print(sys.prefix)") 2>/dev/null`
     AC_MSG_RESULT($PYPREFIX)
     AC_MSG_CHECKING(for Python exec-prefix)
-    PYEPREFIX=`($PYTHON -c "import sys; print sys.exec_prefix") 2>/dev/null`
+    PYEPREFIX=`($PYTHON -c "import sys; print(sys.exec_prefix)") 2>/dev/null`
     AC_MSG_RESULT($PYEPREFIX)
 
 
@@ -128,13 +128,13 @@ if test -n "$PYTHON"; then
 
     # Need to do this hack since autoconf replaces __file__ with the name of the configure file
     filehack="file__"
-    PYVERSION=`($PYTHON -c "import string,operator,os.path; print operator.getitem(os.path.split(operator.getitem(os.path.split(string.__$filehack),0)),1)")`
+    PYVERSION=`($PYTHON -c "import string,operator,os.path; print(operator.getitem(os.path.split(operator.getitem(os.path.split(string.__$filehack),0)),1))")`
     AC_MSG_RESULT($PYVERSION)
 
     # Find the directory for libraries this is necessary to deal with
     # platforms that can have apps built for multiple archs: e.g. x86_64
     AC_MSG_CHECKING(for Python lib dir)
-    PYLIBDIR=`($PYTHON -c "import sys; print sys.lib") 2>/dev/null`
+    PYLIBDIR=`($PYTHON -c "import sys; print(sys.lib)") 2>/dev/null`
     if test -z "$PYLIBDIR"; then
       # older versions don't have sys.lib  so the best we can do is assume lib
       #PYLIBDIR="lib$LIBPOSTFIX"
@@ -159,7 +159,7 @@ if test -n "$PYTHON"; then
     AC_MSG_RESULT($PYLIBDIR)
 
     AC_MSG_CHECKING(for Python site-dir)
-    PYSITEDIR=`($PYTHON -c "from distutils.sysconfig import get_python_lib; print get_python_lib(plat_specific=1)") 2>/dev/null`
+    PYSITEDIR=`($PYTHON -c "from distutils.sysconfig import get_python_lib; print(get_python_lib(plat_specific=1))") 2>/dev/null`
     if test -z "$PYSITEDIR"; then
       # I'm not really sure if it should be installed at /usr/lib64...
       if test -d "$PYEPREFIX/lib$LIBPOSTFIX/$PYVERSION/site-packages"; then

--- a/module/swig/python/setup.py.in
+++ b/module/swig/python/setup.py.in
@@ -89,14 +89,14 @@ my_extra_compile_args = [ '-D_FILE_OFFSET_BITS=64' ]
 my_extra_link_args = [ ]
 
 if bsd_fixes:
-    my_extra_link_args = my_extra_link_args + str.split('../../owlib/src/c/.libs/libow.so', ' ')
+    my_extra_link_args = my_extra_link_args + '../../owlib/src/c/.libs/libow.so'.split(' ')
 
 my_libraries = [ 'ow' ]
 
 #if ARCH == "x64":
 #    my_extra_objects = [ '../../owlib/src/c/.libs/libow.a' ]
 #    my_libraries = [ ]
-#    #my_extra_link_args = my_extra_link_args + str.split('-Wl,--export-dynamic', ' ')
+#    #my_extra_link_args = my_extra_link_args + '-Wl,--export-dynamic'.split(' ')
 #elif ARCH != "x64":
 #    my_extra_objects = ""
 #    my_libraries = [ 'ow' ]

--- a/module/swig/python/setup.py.in
+++ b/module/swig/python/setup.py.in
@@ -21,16 +21,11 @@ distutils setup file for use in creating a Python module from the owfs
 project.
 """
 
-# allows one to use the python3 syntax for print()
-from __future__ import print_function
-
 import os
-# platform doesn't exist for python 2.2
-#import platform
+
 from distutils.core import setup, Extension
 from distutils import sysconfig
 
-#python_version = platform.python_version()[0:3]
 python_version = sysconfig.get_config_vars()["VERSION"]
 
 
@@ -106,24 +101,12 @@ if bsd_fixes:
 
 removals = ['-Wstrict-prototypes']
    
-if python_version == '2.5':
-    cv_opt = sysconfig.get_config_vars()["CFLAGS"]
-    for removal in removals:
-        cv_opt = cv_opt.replace(removal, " ")
-    sysconfig.get_config_vars()["CFLAGS"] = ' '.join(cv_opt.split())
-    cv_opt = ' '.join(my_extra_compile_args)
-    for removal in removals:
-        cv_opt = cv_opt.replace(removal, " ")
-    my_extra_compile_args = ' '.join(cv_opt.split())
-else:
-    cv_opt = sysconfig.get_config_vars()["OPT"]
-    for removal in removals:
-        cv_opt = cv_opt.replace(removal, " ")
-    sysconfig.get_config_vars()["OPT"] = ' '.join(cv_opt.split())
-#    cv_opt = ' '.join(my_extra_compile_args)
-#    my_extra_compile_args = ' '.join(cv_opt.split())
+cv_opt = sysconfig.get_config_vars()["OPT"]
+for removal in removals:
+    cv_opt = cv_opt.replace(removal, " ")
+sysconfig.get_config_vars()["OPT"] = ' '.join(cv_opt.split())
 
-			
+
 #print "my_extra_compile_args=", my_extra_compile_args
 my_extra_compile_args = [ arg for arg in my_extra_compile_args if len(arg) > 1 ]
 #print "my_extra_compile_args=", my_extra_compile_args
@@ -141,14 +124,14 @@ write_configuration(my_define_macros, my_include_dirs, my_libraries, my_library_
 setup(
     name             = 'ow',
     description      = '1-wire hardware interface.',
-    version          = '@VERSION@',
+    version          = '@VERSION@'.replace('p', '.'),
     author           = 'Peter Kropf',
     author_email     = 'pkropf@gmail.com',
     url              = 'http://www.owfs.org/',
     license          = 'GPL',
     platforms        = 'Linux',
     long_description = 'Interface with 1-wire controllers and sensors from Python.',
-    classifiers      = filter( None, classifiers.split( '\n' ) ),
+    classifiers      = classifiers.split( '\n' ),
     packages         = ['ow'],
     ext_package      = 'ow',
     ext_modules      = [ Extension( '_OW',

--- a/module/swig/python/unittest/ds1420.py
+++ b/module/swig/python/unittest/ds1420.py
@@ -28,17 +28,19 @@ address/  crc8/  family/  id/  present/  type/
 import unittest
 import sys
 import os
-import ConfigParser
+import configparser
 import ow
 
 
 __version__ = '0.0'
 
-if not os.path.exists( 'owtest.ini' ):
-    raise IOError('owtest.ini')
+curr_dir = os.path.dirname(os.path.realpath(__file__))
 
-config = ConfigParser.ConfigParser( )
-config.read( 'owtest.ini' )
+if not os.path.exists(os.path.join(curr_dir, 'owtest.ini')):
+    raise IOError(os.path.join(curr_dir, 'owtest.ini'))
+
+config = configparser.ConfigParser( )
+config.read(os.path.join(curr_dir, 'owtest.ini'))
 
 sensors = [ name for name in config.get( 'Root', 'sensors' ).split( ' ' ) ]
 sensors = [ '/' + name for name in sensors if config.get( name, 'type' ) == 'DS1420' ]
@@ -54,20 +56,22 @@ class DS1420( unittest.TestCase ):
 
 
     def testAttributes( self ):
-        self.failIfEqual( len( sensors ), 0 )
+        self.assertNotEqual( len( sensors ), 0 )
         for name in sensors:
             sensor = ow.Sensor( name )
             family, id = name[ 1: ].split( '.' )
 
-            self.failUnlessEqual( family + id,                      sensor.address[ :-2 ] )
-            #self.failUnlessEqual( config.get( name, 'crc8' ),       sensor.crc8 )
-            self.failUnlessEqual( family,                           sensor.family )
-            self.failUnlessEqual( id,                               sensor.id )
-            self.failUnlessEqual( config.get( name[ 1: ], 'type' ), sensor.type )
+            self.assertEqual( family + id,                      sensor.address[ :-2 ] )
+            #self.assertEqual( config.get( name, 'crc8' ),       sensor.crc8 )
+            self.assertEqual( family,                           sensor.family )
+            self.assertEqual( id,                               sensor.id )
+            self.assertEqual( config.get( name[ 1: ], 'type' ), sensor.type )
 
 
 def Suite( ):
-    return unittest.makeSuite( DS1420, 'test' )
+    suite = unittest.TestSuite()
+    suite.addTest(DS1420('testAttributes'))
+    return suite
 
 
 if __name__ == "__main__":

--- a/module/swig/python/unittest/ds1420.py
+++ b/module/swig/python/unittest/ds1420.py
@@ -35,7 +35,7 @@ import ow
 __version__ = '0.0'
 
 if not os.path.exists( 'owtest.ini' ):
-    raise IOError, 'owtest.ini'
+    raise IOError('owtest.ini')
 
 config = ConfigParser.ConfigParser( )
 config.read( 'owtest.ini' )

--- a/module/swig/python/unittest/ds2408.py
+++ b/module/swig/python/unittest/ds2408.py
@@ -43,7 +43,7 @@ __version__ = '0.0'
 
 
 if not os.path.exists( 'owtest.ini' ):
-    raise IOError, 'owtest.ini'
+    raise IOError('owtest.ini')
 
 config = ConfigParser.ConfigParser( )
 config.read( 'owtest.ini' )

--- a/module/swig/python/unittest/ds2408.py
+++ b/module/swig/python/unittest/ds2408.py
@@ -34,19 +34,20 @@ sensed.BYTE/ set_alarm/ strobe/   type/
 import unittest
 import sys
 import os
-import ConfigParser
+import configparser
 import ow
 import util
 
 
 __version__ = '0.0'
 
+curr_dir = os.path.dirname(os.path.realpath(__file__))
 
-if not os.path.exists( 'owtest.ini' ):
-    raise IOError('owtest.ini')
+if not os.path.exists(os.path.join(curr_dir, 'owtest.ini')):
+    raise IOError(os.path.join(curr_dir, 'owtest.ini'))
 
-config = ConfigParser.ConfigParser( )
-config.read( 'owtest.ini' )
+config = configparser.ConfigParser( )
+config.read(os.path.join(curr_dir, 'owtest.ini'))
 
 sensors = util.find_config( config, 'DS2408' )
 if len( sensors ):
@@ -61,137 +62,139 @@ class DS2408( unittest.TestCase ):
 
 
     def testAttributes( self ):
-        self.failIfEqual( len( sensors ), 0 )
+        self.assertNotEqual( len( sensors ), 0 )
         for name in sensors:
             sensor = ow.Sensor( name )
             family, id = name.split( '/' )[ -1 ].split( '.' )
 
-            self.failUnlessEqual( family + id,                      sensor.address[ :-2 ] )
+            self.assertEqual( family + id,                      sensor.address[ :-2 ] )
             #self.failUnlessEqual( config.get( name, 'crc8' ),       sensor.crc8 )
-            self.failUnlessEqual( family,                           sensor.family )
-            self.failUnlessEqual( id,                               sensor.id )
-            self.failUnlessEqual( '1',                              sensor.present )
-            self.failUnlessEqual( config.get( name.split( '/' )[ -1 ], 'type' ), sensor.type )
+            self.assertEqual( family,                           sensor.family )
+            self.assertEqual( id,                               sensor.id )
+            self.assertEqual( '1',                              sensor.present )
+            self.assertEqual( config.get( name.split( '/' )[ -1 ], 'type' ), sensor.type )
 
-            self.failUnlessEqual( hasattr( sensor, 'PIO_0' ),       True )
-            self.failUnlessEqual( hasattr( sensor, 'PIO_1' ),       True )
-            self.failUnlessEqual( hasattr( sensor, 'PIO_2' ),       True )
-            self.failUnlessEqual( hasattr( sensor, 'PIO_3' ),       True )
-            self.failUnlessEqual( hasattr( sensor, 'PIO_4' ),       True )
-            self.failUnlessEqual( hasattr( sensor, 'PIO_5' ),       True )
-            self.failUnlessEqual( hasattr( sensor, 'PIO_6' ),       True )
-            self.failUnlessEqual( hasattr( sensor, 'PIO_7' ),       True )
-            self.failUnlessEqual( hasattr( sensor, 'PIO_ALL' ),     True )
-            self.failUnlessEqual( hasattr( sensor, 'PIO_BYTE' ),    True )
-            self.failUnlessEqual( hasattr( sensor, 'latch_0' ),     True )
-            self.failUnlessEqual( hasattr( sensor, 'latch_1' ),     True )
-            self.failUnlessEqual( hasattr( sensor, 'latch_2' ),     True )
-            self.failUnlessEqual( hasattr( sensor, 'latch_3' ),     True )
-            self.failUnlessEqual( hasattr( sensor, 'latch_4' ),     True )
-            self.failUnlessEqual( hasattr( sensor, 'latch_5' ),     True )
-            self.failUnlessEqual( hasattr( sensor, 'latch_6' ),     True )
-            self.failUnlessEqual( hasattr( sensor, 'latch_7' ),     True )
-            self.failUnlessEqual( hasattr( sensor, 'latch_ALL' ),   True )
-            self.failUnlessEqual( hasattr( sensor, 'latch_BYTE' ),  True )
-            self.failUnlessEqual( hasattr( sensor, 'power' ),       True )
-            self.failUnlessEqual( hasattr( sensor, 'reset' ),       True )
-            self.failUnlessEqual( hasattr( sensor, 'sensed_0' ),    True )
-            self.failUnlessEqual( hasattr( sensor, 'sensed_1' ),    True )
-            self.failUnlessEqual( hasattr( sensor, 'sensed_2' ),    True )
-            self.failUnlessEqual( hasattr( sensor, 'sensed_3' ),    True )
-            self.failUnlessEqual( hasattr( sensor, 'sensed_4' ),    True )
-            self.failUnlessEqual( hasattr( sensor, 'sensed_5' ),    True )
-            self.failUnlessEqual( hasattr( sensor, 'sensed_6' ),    True )
-            self.failUnlessEqual( hasattr( sensor, 'sensed_7' ),    True )
-            self.failUnlessEqual( hasattr( sensor, 'sensed_ALL' ),  True )
-            self.failUnlessEqual( hasattr( sensor, 'sensed_BYTE' ), True )
-            self.failUnlessEqual( hasattr( sensor, 'set_alarm' ),   True )
-            self.failUnlessEqual( hasattr( sensor, 'strobe' ),      True )
+            self.assertEqual( hasattr( sensor, 'PIO_0' ),       True )
+            self.assertEqual( hasattr( sensor, 'PIO_1' ),       True )
+            self.assertEqual( hasattr( sensor, 'PIO_2' ),       True )
+            self.assertEqual( hasattr( sensor, 'PIO_3' ),       True )
+            self.assertEqual( hasattr( sensor, 'PIO_4' ),       True )
+            self.assertEqual( hasattr( sensor, 'PIO_5' ),       True )
+            self.assertEqual( hasattr( sensor, 'PIO_6' ),       True )
+            self.assertEqual( hasattr( sensor, 'PIO_7' ),       True )
+            self.assertEqual( hasattr( sensor, 'PIO_ALL' ),     True )
+            self.assertEqual( hasattr( sensor, 'PIO_BYTE' ),    True )
+            self.assertEqual( hasattr( sensor, 'latch_0' ),     True )
+            self.assertEqual( hasattr( sensor, 'latch_1' ),     True )
+            self.assertEqual( hasattr( sensor, 'latch_2' ),     True )
+            self.assertEqual( hasattr( sensor, 'latch_3' ),     True )
+            self.assertEqual( hasattr( sensor, 'latch_4' ),     True )
+            self.assertEqual( hasattr( sensor, 'latch_5' ),     True )
+            self.assertEqual( hasattr( sensor, 'latch_6' ),     True )
+            self.assertEqual( hasattr( sensor, 'latch_7' ),     True )
+            self.assertEqual( hasattr( sensor, 'latch_ALL' ),   True )
+            self.assertEqual( hasattr( sensor, 'latch_BYTE' ),  True )
+            self.assertEqual( hasattr( sensor, 'power' ),       True )
+            self.assertEqual( hasattr( sensor, 'reset' ),       True )
+            self.assertEqual( hasattr( sensor, 'sensed_0' ),    True )
+            self.assertEqual( hasattr( sensor, 'sensed_1' ),    True )
+            self.assertEqual( hasattr( sensor, 'sensed_2' ),    True )
+            self.assertEqual( hasattr( sensor, 'sensed_3' ),    True )
+            self.assertEqual( hasattr( sensor, 'sensed_4' ),    True )
+            self.assertEqual( hasattr( sensor, 'sensed_5' ),    True )
+            self.assertEqual( hasattr( sensor, 'sensed_6' ),    True )
+            self.assertEqual( hasattr( sensor, 'sensed_7' ),    True )
+            self.assertEqual( hasattr( sensor, 'sensed_ALL' ),  True )
+            self.assertEqual( hasattr( sensor, 'sensed_BYTE' ), True )
+            self.assertEqual( hasattr( sensor, 'set_alarm' ),   True )
+            self.assertEqual( hasattr( sensor, 'strobe' ),      True )
 
 
     def testSet( self ):
-        self.failIfEqual( len( sensors ), 0 )
+        self.assertNotEqual( len( sensors ), 0 )
         for name in sensors:
             sensor = ow.Sensor( name )
 
             sensor.PIO_0 = '0'
             #print sensor._path + '/PIO.0'
-            self.failUnlessEqual( ow._OW.get( sensor._path + '/PIO.0' ), '0' )
-            self.failUnlessEqual( sensor.PIO_0, '0' )
-            self.failUnlessEqual( 'PIO_0' in dir( sensor ), False )
+            self.assertEqual( ow._OW.get( sensor._path + '/PIO.0' ), '0' )
+            self.assertEqual( sensor.PIO_0, '0' )
+            self.assertEqual( 'PIO_0' in dir( sensor ), False )
 
             sensor.PIO_0 = '1'
-            self.failUnlessEqual( sensor.PIO_0, '1' )
-            self.failUnlessEqual( 'PIO_0' in dir( sensor ), False )
+            self.assertEqual( sensor.PIO_0, '1' )
+            self.assertEqual( 'PIO_0' in dir( sensor ), False )
 
 
             sensor.PIO_1 = '0'
-            self.failUnlessEqual( sensor.PIO_1, '0' )
-            self.failUnlessEqual( 'PIO_1' in dir( sensor ), False )
+            self.assertEqual( sensor.PIO_1, '0' )
+            self.assertEqual( 'PIO_1' in dir( sensor ), False )
 
             sensor.PIO_1 = '1'
-            self.failUnlessEqual( sensor.PIO_1, '1' )
-            self.failUnlessEqual( 'PIO_1' in dir( sensor ), False )
+            self.assertEqual( sensor.PIO_1, '1' )
+            self.assertEqual( 'PIO_1' in dir( sensor ), False )
 
 
             sensor.PIO_2 = '0'
-            self.failUnlessEqual( sensor.PIO_2, '0' )
-            self.failUnlessEqual( 'PIO_2' in dir( sensor ), False )
+            self.assertEqual( sensor.PIO_2, '0' )
+            self.assertEqual( 'PIO_2' in dir( sensor ), False )
 
             sensor.PIO_2 = '1'
-            self.failUnlessEqual( sensor.PIO_2, '1' )
-            self.failUnlessEqual( 'PIO_2' in dir( sensor ), False )
+            self.assertEqual( sensor.PIO_2, '1' )
+            self.assertEqual( 'PIO_2' in dir( sensor ), False )
 
 
             sensor.PIO_3 = '0'
-            self.failUnlessEqual( sensor.PIO_3, '0' )
-            self.failUnlessEqual( 'PIO_3' in dir( sensor ), False )
+            self.assertEqual( sensor.PIO_3, '0' )
+            self.assertEqual( 'PIO_3' in dir( sensor ), False )
 
             sensor.PIO_3 = '1'
-            self.failUnlessEqual( sensor.PIO_3, '1' )
-            self.failUnlessEqual( 'PIO_3' in dir( sensor ), False )
+            self.assertEqual( sensor.PIO_3, '1' )
+            self.assertEqual( 'PIO_3' in dir( sensor ), False )
 
 
             sensor.PIO_4 = '0'
-            self.failUnlessEqual( sensor.PIO_4, '0' )
-            self.failUnlessEqual( 'PIO_4' in dir( sensor ), False )
+            self.assertEqual( sensor.PIO_4, '0' )
+            self.assertEqual( 'PIO_4' in dir( sensor ), False )
 
             sensor.PIO_4 = '1'
-            self.failUnlessEqual( sensor.PIO_4, '1' )
-            self.failUnlessEqual( 'PIO_4' in dir( sensor ), False )
+            self.assertEqual( sensor.PIO_4, '1' )
+            self.assertEqual( 'PIO_4' in dir( sensor ), False )
 
 
             sensor.PIO_5 = '0'
-            self.failUnlessEqual( sensor.PIO_5, '0' )
-            self.failUnlessEqual( 'PIO_5' in dir( sensor ), False )
+            self.assertEqual( sensor.PIO_5, '0' )
+            self.assertEqual( 'PIO_5' in dir( sensor ), False )
 
             sensor.PIO_5 = '1'
-            self.failUnlessEqual( sensor.PIO_5, '1' )
-            self.failUnlessEqual( 'PIO_5' in dir( sensor ), False )
+            self.assertEqual( sensor.PIO_5, '1' )
+            self.assertEqual( 'PIO_5' in dir( sensor ), False )
 
 
             sensor.PIO_6 = '0'
-            self.failUnlessEqual( sensor.PIO_6, '0' )
-            self.failUnlessEqual( 'PIO_6' in dir( sensor ), False )
+            self.assertEqual( sensor.PIO_6, '0' )
+            self.assertEqual( 'PIO_6' in dir( sensor ), False )
 
             sensor.PIO_6 = '1'
-            self.failUnlessEqual( sensor.PIO_6, '1' )
-            self.failUnlessEqual( 'PIO_6' in dir( sensor ), False )
+            self.assertEqual( sensor.PIO_6, '1' )
+            self.assertEqual( 'PIO_6' in dir( sensor ), False )
 
 
             sensor.PIO_7 = '0'
-            self.failUnlessEqual( sensor.PIO_7, '0' )
-            self.failUnlessEqual( 'PIO_7' in dir( sensor ), False )
+            self.assertEqual( sensor.PIO_7, '0' )
+            self.assertEqual( 'PIO_7' in dir( sensor ), False )
 
             sensor.PIO_7 = '1'
-            self.failUnlessEqual( sensor.PIO_7, '1' )
-            self.failUnlessEqual( 'PIO_7' in dir( sensor ), False )
+            self.assertEqual( sensor.PIO_7, '1' )
+            self.assertEqual( 'PIO_7' in dir( sensor ), False )
 
 
 
 def Suite( ):
-    return unittest.makeSuite( DS2408, 'test' )
-
+    suite = unittest.TestSuite()
+    suite.addTest(DS2408('testAttributes'))
+    suite.addTest(DS2408('testSet'))
+    return suite
 
 if __name__ == "__main__":
     if len( sys.argv ) > 1:

--- a/module/swig/python/unittest/ds2409.py
+++ b/module/swig/python/unittest/ds2409.py
@@ -36,7 +36,7 @@ import ow
 __version__ = '0.0'
 
 if not os.path.exists( 'owtest.ini' ):
-    raise IOError, 'owtest.ini'
+    raise IOError('owtest.ini')
 
 config = ConfigParser.ConfigParser( )
 config.read( 'owtest.ini' )

--- a/module/swig/python/unittest/ds2409.py
+++ b/module/swig/python/unittest/ds2409.py
@@ -29,17 +29,19 @@ aux/      branch.1/  branch.BYTE/  crc8/     event.0/    event.ALL/  family/    
 import unittest
 import sys
 import os
-import ConfigParser
+import configparser
 import ow
 
 
 __version__ = '0.0'
 
-if not os.path.exists( 'owtest.ini' ):
-    raise IOError('owtest.ini')
+curr_dir = os.path.dirname(os.path.realpath(__file__))
 
-config = ConfigParser.ConfigParser( )
-config.read( 'owtest.ini' )
+if not os.path.exists(os.path.join(curr_dir, 'owtest.ini')):
+    raise IOError(os.path.join(curr_dir, 'owtest.ini'))
+
+config = configparser.ConfigParser( )
+config.read(os.path.join(curr_dir, 'owtest.ini'))
 
 sensors = [ name for name in config.get( 'Root', 'sensors' ).split( ' ' ) ]
 sensors = [ '/' + name for name in sensors if config.get( name, 'type' ) == 'DS2409' ]
@@ -69,31 +71,33 @@ class DS2409( unittest.TestCase ):
             sensor = ow.Sensor( name )
             family, id = name[ 1: ].split( '.' )
 
-            self.failUnlessEqual( family + id,                      sensor.address[ :-2 ] )
-            #self.failUnlessEqual( config.get( name, 'crc8' ),       sensor.crc8 )
-            self.failUnlessEqual( family,                           sensor.family )
-            self.failUnlessEqual( id,                               sensor.id )
-            self.failUnlessEqual( '1',                              sensor.present )
-            self.failUnlessEqual( config.get( name[ 1: ], 'type' ), sensor.type )
+            self.assertEqual( family + id,                      sensor.address[ :-2 ] )
+            #self.assertEqual( config.get( name, 'crc8' ),       sensor.crc8 )
+            self.assertEqual( family,                           sensor.family )
+            self.assertEqual( id,                               sensor.id )
+            self.assertEqual( '1',                              sensor.present )
+            self.assertEqual( config.get( name[ 1: ], 'type' ), sensor.type )
 
-            self.failUnlessEqual( hasattr( sensor, 'branch_0' ),    True )
-            self.failUnlessEqual( hasattr( sensor, 'branch_1' ),    True )
-            self.failUnlessEqual( hasattr( sensor, 'branch_ALL' ),  True )
-            self.failUnlessEqual( hasattr( sensor, 'branch_BYTE' ), True )
-            self.failUnlessEqual( hasattr( sensor, 'control' ),     True )
-            #self.failUnlessEqual( hasattr( sensor, 'discharge' ),   True )
-            self.failUnlessEqual( hasattr( sensor, 'event_0' ),     True )
-            self.failUnlessEqual( hasattr( sensor, 'event_1' ),     True )
-            self.failUnlessEqual( hasattr( sensor, 'event_ALL' ),   True )
-            self.failUnlessEqual( hasattr( sensor, 'event_BYTE' ),  True )
-            self.failUnlessEqual( hasattr( sensor, 'sensed_0' ),    True )
-            self.failUnlessEqual( hasattr( sensor, 'sensed_1' ),    True )
-            self.failUnlessEqual( hasattr( sensor, 'sensed_ALL' ),  True )
-            self.failUnlessEqual( hasattr( sensor, 'sensed_BYTE' ), True )
+            self.assertEqual( hasattr( sensor, 'branch_0' ),    True )
+            self.assertEqual( hasattr( sensor, 'branch_1' ),    True )
+            self.assertEqual( hasattr( sensor, 'branch_ALL' ),  True )
+            self.assertEqual( hasattr( sensor, 'branch_BYTE' ), True )
+            self.assertEqual( hasattr( sensor, 'control' ),     True )
+            #self.assertEqual( hasattr( sensor, 'discharge' ),   True )
+            self.assertEqual( hasattr( sensor, 'event_0' ),     True )
+            self.assertEqual( hasattr( sensor, 'event_1' ),     True )
+            self.assertEqual( hasattr( sensor, 'event_ALL' ),   True )
+            self.assertEqual( hasattr( sensor, 'event_BYTE' ),  True )
+            self.assertEqual( hasattr( sensor, 'sensed_0' ),    True )
+            self.assertEqual( hasattr( sensor, 'sensed_1' ),    True )
+            self.assertEqual( hasattr( sensor, 'sensed_ALL' ),  True )
+            self.assertEqual( hasattr( sensor, 'sensed_BYTE' ), True )
             
 
 def Suite( ):
-    return unittest.makeSuite( DS2409, 'test' )
+    suite = unittest.TestSuite()
+    suite.addTest(DS2409('testAttributes'))
+    return suite
 
 
 if __name__ == "__main__":

--- a/module/swig/python/unittest/owload.py
+++ b/module/swig/python/unittest/owload.py
@@ -37,7 +37,7 @@ load    = True
 class OWLoad( unittest.TestCase ):
     def setUp( self ):
         if not os.path.exists( 'owtest.ini' ):
-            raise IOError, 'owtest.ini'
+            raise IOError('owtest.ini')
 
         self.config = ConfigParser.ConfigParser( )
         self.config.read( 'owtest.ini' )

--- a/module/swig/python/unittest/owload.py
+++ b/module/swig/python/unittest/owload.py
@@ -27,7 +27,7 @@ of ow.Sensor created.
 import unittest
 import sys
 import os
-import ConfigParser
+import configparser
 
 
 __version__ = '0.0'
@@ -36,22 +36,24 @@ load    = True
 
 class OWLoad( unittest.TestCase ):
     def setUp( self ):
-        if not os.path.exists( 'owtest.ini' ):
-            raise IOError('owtest.ini')
+        curr_dir = os.path.dirname(os.path.realpath(__file__))
 
-        self.config = ConfigParser.ConfigParser( )
-        self.config.read( 'owtest.ini' )
+        if not os.path.exists(os.path.join(curr_dir, 'owtest.ini')):
+            raise IOError(os.path.join(curr_dir, 'owtest.ini'))
 
+        self.config = configparser.ConfigParser( )
+        self.config.read(os.path.join(curr_dir, 'owtest.ini'))
 
     def testImport( self ):
-        #print 'OWLoad.testImport'
         import ow
         ow.init( self.config.get( 'General', 'interface' ) )
         s = ow.Sensor( '/' )
 
 
 def Suite( ):
-    return unittest.makeSuite( OWLoad, 'test' )
+    suite = unittest.TestSuite()
+    suite.addTest(OWLoad('testImport'))
+    return suite
 
 
 if __name__ == "__main__":

--- a/module/swig/python/unittest/owsensors.py
+++ b/module/swig/python/unittest/owsensors.py
@@ -38,7 +38,7 @@ class OWSensors( unittest.TestCase ):
     def setUp( self ):
         #print 'OWSensors.setup'
         if not os.path.exists( 'owtest.ini' ):
-            raise IOError, 'owtest.ini'
+            raise IOError('owtest.ini')
 
         self.config = ConfigParser.ConfigParser( )
         self.config.read( 'owtest.ini' )

--- a/module/swig/python/unittest/owsensors.py
+++ b/module/swig/python/unittest/owsensors.py
@@ -26,7 +26,7 @@ Test suite for basic reality checks on a 1-wire nerwork.
 import unittest
 import sys
 import os
-import ConfigParser
+import configparser
 import ow
 
 
@@ -36,12 +36,13 @@ load    = True
 
 class OWSensors( unittest.TestCase ):
     def setUp( self ):
-        #print 'OWSensors.setup'
-        if not os.path.exists( 'owtest.ini' ):
-            raise IOError('owtest.ini')
+        curr_dir = os.path.dirname(os.path.realpath(__file__))
 
-        self.config = ConfigParser.ConfigParser( )
-        self.config.read( 'owtest.ini' )
+        if not os.path.exists(os.path.join(curr_dir, 'owtest.ini')):
+            raise IOError(os.path.join(curr_dir, 'owtest.ini'))
+
+        self.config = configparser.ConfigParser( )
+        self.config.read(os.path.join(curr_dir, 'owtest.ini'))
 
         ow.init( self.config.get( 'General', 'interface' ) )
 
@@ -53,43 +54,38 @@ class OWSensors( unittest.TestCase ):
 
 
     def testRootNameType( self ):
-        #print 'OWSensors.testRootNameType'
         path, name = str( ow.Sensor( '/' ) ).split( ' - ' )
-        self.failUnlessEqual( path, '/' )
-        self.failUnlessEqual( name, self.config.get( 'Root', 'type' ) )
+        self.assertEqual( path, '/' )
+        self.assertEqual( name, self.config.get( 'Root', 'type' ) )
 
 
     def testRootEntries( self ):
-        #print 'OWSensors.testRootEntries'
         entries = list( ow.Sensor( '/' ).entries( ) )
         entries.sort( )
 
-        self.failUnlessEqual( entries, self.entries )
+        self.assertEqual( entries, self.entries )
 
 
     def testSensors( self ):
-        #print 'OWSensors.testSensors'
         sensors = [ str( sensor ).split( ' - ' )[ 0 ] for sensor in ow.Sensor( '/' ).sensors( ) ]
         sensors.sort( )
 
-        self.failUnlessEqual( sensors, self.sensors )
+        self.assertEqual( sensors, self.sensors )
 
 
     def testBaseAttributes( self ):
-        #print 'OWSensors.testBaseAttributes'
         for sensor in ow.Sensor( '/' ).sensors( ):
             name = str( sensor ).split( ' - ' )[ 0 ][ 1: ]
             family, id = name.split( '.' )
 
-            self.failUnlessEqual( family + id,                     sensor.address[ :-2 ] )
-            #self.failUnlessEqual( self.config.get( name, 'crc8' ), sensor.crc8 )
-            self.failUnlessEqual( family,                          sensor.family )
-            self.failUnlessEqual( id,                              sensor.id )
-            self.failUnlessEqual( self.config.get( name, 'type' ), sensor.type )
+            self.assertEqual( family + id,                     sensor.address[ :-2 ] )
+            #self.assertEqual( self.config.get( name, 'crc8' ), sensor.crc8 )
+            self.assertEqual( family,                          sensor.family )
+            self.assertEqual( id,                              sensor.id )
+            self.assertEqual( self.config.get( name, 'type' ), sensor.type )
 
 
     def testFindAnyValue( self ):
-        #print 'OWSensors.testFindAnyValue'
         type_list = { }
 
         for id in self.config.get( 'Root', 'sensors' ).split( ' ' ):
@@ -101,20 +97,20 @@ class OWSensors( unittest.TestCase ):
 
         for id_type in type_list:
             sensor_list = [ sensor for sensor in ow.Sensor( '/' ).find( type = id_type ) ]
-            self.failUnlessEqual( len( sensor_list ), type_list[ id_type ] )
+            self.assertEqual( len( sensor_list ), type_list[ id_type ] )
 
 
     def testFindAnyNoValue( self ):
         #print 'OWSensors.testFindAnyNoValue'
         type_count = len( self.config.get( 'Root', 'sensors' ).split( ' ' ) )
         sensor_list = [ sensor for sensor in ow.Sensor( '/' ).find( type = None ) ]
-        self.failUnlessEqual( len( sensor_list ), type_count )
+        self.assertEqual( len( sensor_list ), type_count )
 
 
     def testFindAnyNone( self ):
         #print 'OWSensors.testFindNone'
         sensor_list = [ sensor for sensor in ow.Sensor( '/' ).find( xyzzy = None ) ]
-        self.failUnlessEqual( len( sensor_list ), 0 )
+        self.assertEqual( len( sensor_list ), 0 )
 
 
     def testFindAll( self ):
@@ -133,11 +129,10 @@ class OWSensors( unittest.TestCase ):
             sensor_list = [ sensor for sensor in ow.Sensor( '/' ).find( all = True,
                                                                         family = pair[ 0 ],
                                                                         type = pair[ 1 ] ) ]
-            self.failUnlessEqual( len( sensor_list ), list[ pair ] )
+            self.assertEqual( len( sensor_list ), list[ pair ] )
 
 
     def testFindAllNone( self ):
-        #print 'OWSensors.testFindAllNone'
         list = { }
 
         for id in self.config.get( 'Root', 'sensors' ).split( ' ' ):
@@ -153,22 +148,22 @@ class OWSensors( unittest.TestCase ):
                                                                         xyzzy = True,
                                                                         family = pair[ 0 ],
                                                                         type = pair[ 1 ] ) ]
-            self.failUnlessEqual( len( sensor_list ), 0 )
+            self.assertEqual( len( sensor_list ), 0 )
 
 
     def testCacheUncached( self ):
         for id in self.config.get( 'Root', 'sensors' ).split( ' ' ):
             c = ow.Sensor( '/' + id )
             u = ow.Sensor( '/uncached/' + id )
-            self.failUnlessEqual( c._path, u._path )
+            self.assertEqual( c._path, u._path )
 
             ce = [ entry for entry in c.entries( ) ]
             ue = [ entry for entry in u.entries( ) ]
-            self.failUnlessEqual( ce, ue )
+            self.assertEqual( ce, ue )
 
             cs = [ sensor for sensor in c.sensors( ) ]
             us = [ sensor for sensor in u.sensors( ) ]
-            self.failUnlessEqual( cs, us )
+            self.assertEqual( cs, us )
 
 
     def testCacheSwitch( self ):
@@ -182,8 +177,8 @@ class OWSensors( unittest.TestCase ):
             ue = s.entryList( )
             us = s.sensorList( )
 
-            self.failUnlessEqual( ce, ue )
-            self.failUnlessEqual( cs, us )
+            self.assertEqual( ce, ue )
+            self.assertEqual( cs, us )
 
 
     def testRootCache( self ):
@@ -195,8 +190,8 @@ class OWSensors( unittest.TestCase ):
         ue = r.entryList( )
         us = r.sensorList( )
 
-        self.failUnlessEqual( cs, us )
-        self.failUnlessEqual( ue, [ 'alarm', 'simultaneous' ] )
+        self.assertEqual( cs, us )
+        self.assertEqual( ue, [ 'alarm', 'simultaneous' ] )
 
 
     def testEntryList( self ):
@@ -205,12 +200,12 @@ class OWSensors( unittest.TestCase ):
             u = ow.Sensor( '/uncached/' + id )
 
             ce = [ entry for entry in c.entries( ) ]
-            self.failUnlessEqual( ce, c.entryList( ) )
+            self.assertEqual( ce, c.entryList( ) )
 
             ue = [ entry for entry in u.entries( ) ]
-            self.failUnlessEqual( ue, u.entryList( ) )
+            self.assertEqual( ue, u.entryList( ) )
 
-            self.failUnlessEqual( ce, ue )
+            self.assertEqual( ce, ue )
 
 
     def testSensorList( self ):
@@ -219,25 +214,41 @@ class OWSensors( unittest.TestCase ):
             u = ow.Sensor( '/uncached/' + id )
 
             cs = [ sensor for sensor in c.sensors( ) ]
-            self.failUnlessEqual( cs, c.sensorList( ) )
+            self.assertEqual( cs, c.sensorList( ) )
 
             us = [ sensor for sensor in u.sensors( ) ]
-            self.failUnlessEqual( us, u.sensorList( ) )
+            self.assertEqual( us, u.sensorList( ) )
 
-            self.failUnlessEqual( cs, us )
+            self.assertEqual( cs, us )
 
 
     def testEqual( self ):
         s1 = ow.Sensor( '/' )
         s2 = ow.Sensor( '/' )
         s3 = ow.Sensor( self.config.get( 'Root', 'sensors' ).split( ' ' )[ 0 ] )
-        self.failUnlessEqual( s1, s2 )
-        self.failIfEqual( s1, s3 )
-        self.failIfEqual( s2, s3 )
+        self.assertEqual( s1, s2 )
+        self.assertNotEqual( s1, s3 )
+        self.assertNotEqual( s2, s3 )
 
 
 def Suite( ):
-    return unittest.makeSuite( OWSensors, 'test' )
+    suite = unittest.TestSuite()
+    suite.addTest(OWSensors('testRootNameType'))
+    suite.addTest(OWSensors('testRootEntries'))
+    suite.addTest(OWSensors('testSensors'))
+    suite.addTest(OWSensors('testBaseAttributes'))
+    suite.addTest(OWSensors('testFindAnyValue'))
+    suite.addTest(OWSensors('testFindAnyNoValue'))
+    suite.addTest(OWSensors('testFindAnyNone'))
+    suite.addTest(OWSensors('testFindAll'))
+    suite.addTest(OWSensors('testFindAllNone'))
+    suite.addTest(OWSensors('testCacheUncached'))
+    suite.addTest(OWSensors('testCacheSwitch'))
+    suite.addTest(OWSensors('testRootCache'))
+    suite.addTest(OWSensors('testEntryList'))
+    suite.addTest(OWSensors('testSensorList'))
+    suite.addTest(OWSensors('testEqual'))
+    return suite
 
 
 if __name__ == "__main__":

--- a/module/swig/python/unittest/owtest.py
+++ b/module/swig/python/unittest/owtest.py
@@ -46,13 +46,13 @@ def Suite( ):
             continue
         name = name[:-3]
         try:
-            exec 'import ' + name
-            exec 'load = ' + name + '.load'
+            exec('import ' + name)
+            exec('load = ' + name + '.load')
             if load:
-                exec 'suite = ' + name + '.Suite( )'
+                exec('suite = ' + name + '.Suite( )')
                 test_suites = unittest.TestSuite( ( test_suites, suite ) )
         except AttributeError:
-            print 'skipping ' + name + ' no Suite function found.'
+            print('skipping ' + name + ' no Suite function found.')
             pass
     return test_suites
 


### PR DESCRIPTION
This is based on the discussions of the still opened PR: https://github.com/owfs/owfs/pull/26 & https://github.com/owfs/owfs/pull/32

This PR mainly aims to remove the annoying error when compiling without disabling python support and fix https://github.com/owfs/owfs/issues/75

It includes the port of:

  - module/swig/python/examples
  - module/swig/python/unittest
  - module/swig/setup.py.in (fix of the `.split` method and `version=` attribute)
  - module/ownet/python/example